### PR TITLE
fix: Add version command to `glu`

### DIFF
--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -1,7 +1,32 @@
 import typer
-from glu.cli import ticket, pr
+
+from glu import __version__
+from glu.cli import pr, ticket
 
 app = typer.Typer()
+
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show the version and exit",
+    ),
+):
+    if ctx.invoked_subcommand is None and not version:
+        typer.echo(ctx.get_help())
+
+
 app.add_typer(pr.app, name="pr")
 app.add_typer(ticket.app, name="ticket")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,18 @@ build-backend = "hatchling.build"
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["glu/__init__.py:__version__"]
 commit_message = "chore(release): v{version} [skip ci]"
+
+[tool.ruff]
+line-length = 100  # due to comments, this may be longer
+lint.select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "C",  # flake8-comprehensions
+    "B",  # flake8-bugbear
+    "ARG001",  # unused-function-argument
+    "ARG002",  # unused-method-argument
+    "F841",    # unused-variable (catches args too)
+    "T201",    # flake8-print
+]

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "glu"
-version = "0.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-6]
- **Summary**:  
  Introduce a top‐level `--version` option to the `glu` CLI, standardize import ordering, refactor the ticket creation flow for better defaults and field resolution, bump the package version to 1.2.0, and add a Ruff linting configuration.
- **Implementation details**:  
  - In `glu/cli/main.py`, add an eager `--version` flag and callback to display `__version__`.  
  - Reorder imports in both CLI modules for consistency.  
  - In `glu/cli/ticket.py`, swap in‐line import ordering, use helper functions `get_jira_project` and `get_user_from_jira`, clean up option formatting, and ensure the `issuetype` field is named correctly.  
  - Update `pyproject.toml` with Ruff lint rules and bump `glu` version to 1.2.0 in the lockfile.

### Changes

- **glu/cli/main.py**  
  - Added `version_callback` and configured `--version` as an eager global option.  
  - On invocation without commands, prints help.
- **glu/cli/ticket.py**  
  - Reorganized import order.  
  - Moved AI and Jira helper imports into logical groups.  
  - Cleaned up Typer option definitions (single‐line annotations).  
  - Leveraged `get_jira_project` for default project and fixed `issuetype` key.  
- **pyproject.toml**  
  - Added `[tool.ruff]` section with selected lint rules.  
- **uv.lock**  
  - Bumped `glu` version from `0.1.0` to `1.2.0`.

### Test Plan

1. Run `glu --version` to confirm it prints `1.2.0` and exits.  
2. Execute `glu pr --help` and `glu ticket --help` to verify no regression in help text.  
3. Create a Jira ticket via `glu ticket create` with and without AI prompts, ensuring defaults (project, issuetype) are populated.  
4. Validate Ruff linter passes (`ruff .`).

### Dependencies

- No new runtime dependencies introduced.  
- Added Ruff linting tool configuration only.

### Future Enhancements / Open questions / Risks / Technical Debt

- Typer currently lacks Union type support for options—track upstream PR #1148 for native `ai_prompt` typing.  
- Consider exposing more Jira fields (components, labels) in future CLI options.

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] If necessary, documentation has been updated.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself, to guide reviewers and future coders through my changes and the intended results.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken to not necessitate backward compatibility.

[GLU-6]: https://brightnight.atlassian.net/browse/GLU-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ