### PR TITLE
feat: Enhance ai-driven commit and ticket generation with cli integration

### DIFF
--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -27,8 +27,8 @@ def main(
         typer.echo(ctx.get_help())
 
 
-app.add_typer(pr.app, name="pr")
-app.add_typer(ticket.app, name="ticket")
+app.add_typer(pr.app, name="pr", help="Interact with pull requests.")
+app.add_typer(ticket.app, name="ticket", help="Interact with Jira tickets.")
 
 if __name__ == "__main__":
     app()

--- a/glu/cli/ticket.py
+++ b/glu/cli/ticket.py
@@ -7,12 +7,17 @@ from InquirerPy import inquirer
 from jira import JIRA
 from typer import Context
 
-from glu.ai import generate_ticket, prompt_for_chat_provider
+from glu.ai import prompt_for_chat_provider
 from glu.config import DEFAULT_JIRA_PROJECT, EMAIL, JIRA_API_TOKEN, JIRA_SERVER
-from glu.git import get_repo_name
-from glu.jira import get_jira_project, get_user_from_jira
-from glu.models import ChatProvider, TicketGeneration
-from glu.utils import get_kwargs, print_error, prompt_or_edit
+from glu.jira import (
+    create_ticket,
+    generate_ticket_with_ai,
+    get_jira_issuetypes,
+    get_jira_project,
+    get_user_from_jira,
+)
+from glu.local import get_repo_name
+from glu.utils import get_kwargs, prompt_or_edit
 
 app = typer.Typer()
 
@@ -67,7 +72,7 @@ def create(
     if not project:
         project = get_jira_project(jira, repo_name)
 
-    types = [issuetype.name for issuetype in jira.issue_types_for_project(project or "")]
+    types = get_jira_issuetypes(jira, project or "")
     if not type:
         issuetype = inquirer.select("Select type:", types).execute()
     else:
@@ -83,10 +88,10 @@ def create(
         # if isinstance(ai_prompt, bool):
         #     prompt = prompt_or_edit('AI Prompt')
         # else:
-        prompt = ai_prompt
+        # prompt = ai_prompt
 
         provider = prompt_for_chat_provider(provider, True)
-        ticket_data = _generate_with_ai_prompt(prompt, provider, issuetype, repo_name)
+        ticket_data = generate_ticket_with_ai(repo_name, provider, issuetype, ai_prompt=ai_prompt)
         summary = ticket_data.summary
         body = ticket_data.description
     else:
@@ -99,84 +104,16 @@ def create(
         if not body:
             body = prompt_or_edit("Description", allow_skip=True)
 
-    reporter_id = get_user_from_jira(jira, reporter)
+    reporter_ref = get_user_from_jira(jira, reporter)
 
-    assignee_id = get_user_from_jira(jira, assignee)
+    assignee_ref = get_user_from_jira(jira, assignee)
 
     if priority:
         extra_fields["priority"] = priority
 
-    fields = extra_fields | {
-        "project": project,
-        "issuetype": issuetype,
-        "description": body,
-        "summary": summary,
-        "reporter": reporter_id,
-        "assignee": assignee_id,
-    }
-
-    issue = jira.create_issue(fields)
+    issue = create_ticket(
+        jira, project, issuetype, summary or "", body, reporter_ref, assignee_ref, **extra_fields
+    )
 
     rich.print(f":page_with_curl: Created issue [bold red]{issue.key}[/]")
     rich.print(f"View at {issue.permalink()}")
-
-
-def _generate_with_ai_prompt(
-    ai_prompt: str,
-    provider: ChatProvider | None,
-    issuetype: str,
-    repo_name: str | None,
-    requested_changes: str | None = None,
-    previous_attempt: TicketGeneration | None = None,
-) -> TicketGeneration:
-    ticket_data = generate_ticket(
-        ai_prompt, issuetype, repo_name, provider, requested_changes, previous_attempt
-    )
-    summary = ticket_data.summary
-    body = ticket_data.description
-
-    rich.print(f"[grey70]Proposed summary:[/]\n{summary}\n")
-    rich.print(f"[grey70]Proposed description:[/]\n{body}")
-
-    proceed_choice = inquirer.select(
-        "How would you like to proceed?",
-        ["Accept", "Edit", "Ask for changes", "Amend prompt and regenerate", "Exit"],
-    ).execute()
-
-    match proceed_choice:
-        case "Accept":
-            return ticket_data
-        case "Edit":
-            edited = typer.edit(f"Summary: {summary}\n\nDescription: {body}")
-            if edited is None:
-                print_error("No description provided")
-                raise typer.Exit(1)
-            summary = edited.split("\n\n")[0].replace("Summary:", "").strip()
-            body = edited.split("\n\n")[1].replace("Description:", "").strip()
-            return TicketGeneration(description=body, summary=summary)
-        case "Ask for changes":
-            requested_changes = typer.edit("")
-            if requested_changes is None:
-                print_error("No changes requested.")
-                raise typer.Exit(1)
-            return _generate_with_ai_prompt(
-                ai_prompt,
-                provider,
-                issuetype,
-                repo_name,
-                requested_changes,
-                ticket_data,
-            )
-        case "Amend prompt and regenerate":
-            amended_prompt = typer.edit(ai_prompt)
-            if amended_prompt is None:
-                print_error("No prompt provided.")
-                raise typer.Exit(1)
-            return _generate_with_ai_prompt(
-                amended_prompt,
-                provider,
-                issuetype,
-                repo_name,
-            )
-        case _:
-            raise typer.Exit(0)

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -1,16 +1,19 @@
+import rich
 import typer
 from InquirerPy import inquirer
 from InquirerPy.base import Choice
-from jira import JIRA
+from jira import JIRA, Issue
 
+from glu.ai import generate_ticket
 from glu.config import REPO_CONFIGS
+from glu.models import ChatProvider, IdReference, TicketGeneration
 from glu.utils import filterable_menu, print_error
 
 
-def get_user_from_jira(jira: JIRA, user_query: str | None) -> dict[str, str]:
+def get_user_from_jira(jira: JIRA, user_query: str | None) -> IdReference:
     myself = jira.myself()
-    if not user_query or user_query in ["me@me"]:
-        return {"id": myself["accountId"]}
+    if not user_query or user_query in ["me", "@me"]:
+        return IdReference(id=myself["accountId"])
 
     users = jira.search_users(query=user_query)
     if not len(users):
@@ -18,14 +21,14 @@ def get_user_from_jira(jira: JIRA, user_query: str | None) -> dict[str, str]:
         raise typer.Exit(1)
 
     if len(users) == 1:
-        return {"id": users[0].accountId}
+        return IdReference(id=users[0].accountId)
 
     choice = inquirer.select(
         "Select reporter:",
         choices=[Choice(user.accountId, user.displayName) for user in users],
     ).execute()
 
-    return {"id": choice}
+    return IdReference(id=choice)
 
 
 def get_jira_project(jira: JIRA, repo_name: str | None, project: str | None = None) -> str:
@@ -41,6 +44,10 @@ def get_jira_project(jira: JIRA, repo_name: str | None, project: str | None = No
     return selected_project
 
 
+def get_jira_issuetypes(jira: JIRA, project: str) -> list[str]:
+    return [issuetype.name for issuetype in jira.issue_types_for_project(project)]
+
+
 def format_jira_ticket(jira_key: str, ticket: str | int) -> str:
     try:
         ticket_num = int(ticket)
@@ -51,3 +58,111 @@ def format_jira_ticket(jira_key: str, ticket: str | int) -> str:
         raise typer.Exit(1) from err
 
     return f"{jira_key}-{ticket_num}"
+
+
+def generate_ticket_with_ai(
+    repo_name: str | None,
+    chat_provider: ChatProvider | None,
+    issuetype: str | None = None,
+    issuetypes: list[str] | None = None,
+    ai_prompt: str | None = None,
+    pr_description: str | None = None,
+    requested_changes: str | None = None,
+    previous_attempt: TicketGeneration | None = None,
+) -> TicketGeneration:
+    ticket_data = generate_ticket(
+        repo_name,
+        chat_provider,
+        issuetype,
+        issuetypes,
+        ai_prompt,
+        pr_description,
+        requested_changes,
+        previous_attempt,
+    )
+    summary = ticket_data.summary
+    body = ticket_data.description
+
+    rich.print(f"[grey70]Proposed summary:[/]\n{summary}\n")
+    rich.print(f"[grey70]Proposed description:[/]\n{body}")
+
+    choices = [
+        "Accept",
+        "Edit",
+        "Ask for changes",
+        f"{'Amend' if ai_prompt else 'Add'} prompt and regenerate",
+        "Exit",
+    ]
+
+    proceed_choice = inquirer.select(
+        "How would you like to proceed?",
+        choices,
+    ).execute()
+
+    match proceed_choice:
+        case "Accept":
+            return ticket_data
+        case "Edit":
+            edited = typer.edit(f"Summary: {summary}\n\nDescription: {body}")
+            if edited is None:
+                print_error("No description provided")
+                raise typer.Exit(1)
+            summary = edited.split("\n\n")[0].replace("Summary:", "").strip()
+            body = edited.split("\n\n")[1].replace("Description:", "").strip()
+            return TicketGeneration(
+                description=body, summary=summary, issuetype=ticket_data.issuetype
+            )
+        case "Ask for changes":
+            requested_changes = typer.edit("")
+            if requested_changes is None:
+                print_error("No changes requested.")
+                raise typer.Exit(1)
+            return generate_ticket_with_ai(
+                repo_name,
+                chat_provider,
+                issuetype,
+                issuetypes,
+                ai_prompt,
+                pr_description,
+                requested_changes,
+                ticket_data,
+            )
+        case s if s.endswith("prompt and regenerate"):
+            amended_prompt = typer.edit(ai_prompt or "")
+            if amended_prompt is None:
+                print_error("No prompt provided.")
+                raise typer.Exit(1)
+            return generate_ticket_with_ai(
+                repo_name,
+                chat_provider,
+                issuetype,
+                issuetypes,
+                amended_prompt,
+                pr_description,
+                requested_changes,
+                ticket_data,
+            )
+        case _:
+            raise typer.Exit(0)
+
+
+def create_ticket(
+    jira: JIRA,
+    project: str,
+    issuetype: str,
+    summary: str,
+    description: str | None,
+    reporter_ref: IdReference,
+    assignee_ref: IdReference,
+    **extra_fields: dict,
+) -> Issue:
+    fields = extra_fields | {
+        "project": project,
+        "issuetype": issuetype,
+        "description": description,
+        "summary": summary,
+        "reporter": reporter_ref.model_dump(),
+        "assignee": assignee_ref.model_dump(),
+    }
+
+    return jira.create_issue(fields)

--- a/glu/local.py
+++ b/glu/local.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 
+import rich
 import typer
-from git import GitCommandError, Repo
+from git import Commit, GitCommandError, HookExecutionError, Repo
+from InquirerPy import inquirer
 
+from glu.ai import generate_commit_message
+from glu.config import PREFERENCES
+from glu.models import ChatProvider, CommitGeneration
 from glu.utils import print_error
 
 
@@ -83,3 +88,57 @@ def remote_branch_in_sync(
     remote_sha = repo.refs[remote_ref_name].commit.hexsha
 
     return local_sha == remote_sha
+
+
+def get_git_diff(repo: Repo | None = None) -> str:
+    repo = repo or get_repo()
+    return repo.git.diff("HEAD")
+
+
+def generate_commit_with_ai(
+    chat_provider: ChatProvider | None,
+    local_repo: Repo,
+) -> CommitGeneration:
+    diff = get_git_diff(local_repo)
+    commit_data = generate_commit_message(chat_provider, diff)
+
+    if PREFERENCES.auto_accept_generated_commits:
+        return commit_data
+
+    rich.print(f"[grey70]Proposed commit:[/]\n{commit_data.message}\n")
+
+    choices = ["Accept", "Edit", "Exit"]
+
+    proceed_choice = inquirer.select(
+        "How would you like to proceed?",
+        choices,
+    ).execute()
+
+    match proceed_choice:
+        case "Accept":
+            return commit_data
+        case "Edit":
+            edited = typer.edit(commit_data.message)
+            if edited is None:
+                print_error("No description provided")
+                raise typer.Exit(1)
+            title_with_type = edited.split("\n\n")[0].strip()
+            body = edited.split("\n\n")[1].strip()
+            return CommitGeneration(
+                title=title_with_type.split(":")[1], body=body, type=title_with_type.split(":")[0]
+            )
+        case _:
+            raise typer.Exit(0)
+
+
+def commit(local_repo: Repo, message: str, retry: int = 0) -> Commit:
+    try:
+        local_repo.git.add(all=True)
+        return local_repo.index.commit(message)
+    except HookExecutionError as err:
+        if retry == 0:
+            rich.print("[warning]Pre-commit hooks failed, retrying...[/]")
+            return commit(local_repo, message, retry + 1)
+
+        rich.print(err)
+        raise typer.Exit(1) from err

--- a/glu/models.py
+++ b/glu/models.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from github.NamedUser import NamedUser
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 ChatProvider = Literal["OpenAI", "Glean"]
 
@@ -18,3 +18,26 @@ class MatchedUser:
 class TicketGeneration(BaseModel):
     description: str
     summary: str
+    issuetype: str
+
+
+class IdReference(BaseModel):
+    id: str
+
+
+class CommitGeneration(BaseModel):
+    title: str
+    body: str
+    type: str
+
+    @model_validator(mode="after")
+    def validate_title(self) -> "CommitGeneration":
+        if self.type in self.title:
+            self.title = self.title.replace(f"{self.type}:", "").strip()
+
+        self.title = self.title.capitalize()
+        return self
+
+    @property
+    def message(self):
+        return f"{self.type}: {self.title}\n\n{self.body}"


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-XXXX]  
- **Summary**: Add AI-powered commit message generation and AI-assisted Jira ticket creation to the CLI, refactor local Git helper module, unify ticket logic, and improve error handling.  
- **Implementation details**:  
  • In glu/ai.py, introduce `generate_commit_message` and `_generate_issuetype`, extend `generate_ticket` to accept either a user prompt or PR description, select issue type via AI, and retry on JSON or validation errors.  
  • Rename `glu/git.py` → `glu/local.py`, implement `generate_commit_with_ai` (with optional auto-accept) and a robust `commit` helper that retries on hook failures.  
  • Update `glu/models.py` with new `CommitGeneration` and `IdReference` models and validation hooks.  
  • In `glu/config.py`, add `Preferences` (auto_accept_generated_commits, preferred_provider), expose `PREFERENCES`, and normalize Jira template keys case-insensitively.  
  • In `glu/jira.py`, add `create_ticket`, `get_jira_issuetypes`, and wrap AI ticket flow in `generate_ticket_with_ai`, using `IdReference` for reporter/assignee.  
  • Update CLI commands (`cli/main.py`, `cli/pr.py`, `cli/ticket.py`) to support AI commit on dirty repos, dynamic ticket creation (prompt or AI), default provider from `PREFERENCES`, and reorganize imports accordingly.

### Changes

- glu/ai.py  
  • New functions: `generate_commit_message`, `_generate_issuetype`  
  • Extended `generate_ticket` to accept `ai_prompt`/`pr_description`, optional `issuetypes`, auto-select issuetype, improved JSON/Pydantic error handling with retries.  
- glu/local.py (was glu/git.py)  
  • New helpers: `get_git_diff`, `generate_commit_with_ai`, `commit` (with hook retry)  
  • Respects `PREFERENCES.auto_accept_generated_commits`  
- glu/models.py  
  • Added `CommitGeneration`, `IdReference` models  
  • Validator to clean up commit title and type  
- glu/config.py  
  • New `Preferences` model, `preferences` field, and global `PREFERENCES`  
  • Validator to lowercase Jira template config keys  
- glu/jira.py  
  • New helpers: `get_jira_issuetypes`, `create_ticket`  
  • Refactored `get_user_from_jira` to return `IdReference`  
  • Wrapped AI ticket flow in `generate_ticket_with_ai`  
- CLI updates  
  • cli/main.py: add help text for sub‐commands  
  • cli/pr.py: prompt AI or manual commit on dirty repo, offer AI-powered ticket creation after PR, use new local and jira helpers  
  • cli/ticket.py: use `generate_ticket_with_ai` and `create_ticket` instead of inline logic, fetch issuetypes via helper  

### Test Plan

1. On a dirty repository, invoke `glu pr create` and verify AI commit suggestion, edit/accept flows, push behavior.  
2. Run `glu ticket create` with and without `--ai-prompt`; verify issue type selection, summary/description cycles, and actual ticket creation in Jira sandbox.  
3. Confirm config loads `preferences` and honors `preferred_provider` and `auto_accept_generated_commits`.  
4. Test error recovery by simulating malformed AI responses (e.g. bad JSON) and forcing retry logic.  
5. Validate case-insensitive lookup of Jira templates in config.

### Dependencies

- pydantic (using `field_validator` and `model_validator`)  
- (no new external packages beyond existing InquirerPy, jira, langchain_glean, etc.)

### Future Enhancements / Open questions / Risks / Technical Debt

- Persist CLI preferences (e.g. provider default) across sessions (currently in memory).  
- Surface AI provider quota or error details more verbosely.  
- Potential duplication between `generate_ticket` in ai.py and wrapper in jira.py—consider consolidating further.  
- Unit tests for retry/error branches in AI flows remain to be written.

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] Documentation has been updated where necessary.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: code is backward compatible or documented migration steps provided.