### PR TITLE
feat: Add ai-powered commit messages and enhance pr/ticket workflows

### DIFF
--- a/glu/ai.py
+++ b/glu/ai.py
@@ -1,26 +1,29 @@
-import datetime as dt
 import json
 import os
 from json import JSONDecodeError
 
 import rich
 import typer
-from github import Github
-from github.PullRequest import PullRequest
+from git import Repo
 from github.Repository import Repository
 from InquirerPy import inquirer
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_glean import ChatGlean
+from pydantic import ValidationError
 
 from glu import ROOT_DIR
-from glu.config import JIRA_ISSUE_TEMPLATES, REPO_CONFIGS
-from glu.models import ChatProvider, TicketGeneration
+from glu.config import JIRA_ISSUE_TEMPLATES, PREFERENCES, REPO_CONFIGS
+from glu.models import ChatProvider, CommitGeneration, TicketGeneration
 from glu.utils import print_error
 
 
 def generate_description(
-    gh: Github, repo: Repository, pr: PullRequest, chat_provider: ChatProvider | None
+    repo: Repository,
+    local_repo: Repo,
+    body: str,
+    chat_provider: ChatProvider | None,
+    jira_project: str | None,
 ) -> str | None:
     chat = _get_chat_model(chat_provider)
     if not chat:
@@ -30,7 +33,7 @@ def generate_description(
     try:
         template_file = repo.get_contents(template_dir, ref="main")
         if isinstance(template_file, list):
-            template = None
+            template = template_file[0].decoded_content.decode() if len(template_file) else None
         else:
             template = template_file.decoded_content.decode()
     except Exception:
@@ -42,40 +45,25 @@ def generate_description(
         else:
             with open(ROOT_DIR / template_dir, "r", encoding="utf-8") as f:
                 template = f.read()
+            if jira_project:
+                template = template.replace("GLU", jira_project)
 
-    # informs whether to provide the diff or a URL (since indexing should be done)
-    is_newly_created_pr = dt.datetime.now(dt.timezone.utc) - pr.created_at < dt.timedelta(
-        minutes=15
+    diff = local_repo.git.diff(
+        getattr(local_repo.heads, repo.default_branch).commit.hexsha, local_repo.head.commit.hexsha
     )
-    using_glean = isinstance(chat, ChatGlean)
-
-    pr_location = "diff below" if is_newly_created_pr or not using_glean else pr.html_url
-
-    pr_diff_str = ""
-    if is_newly_created_pr:
-        headers = {"Accept": "application/vnd.github.v3.diff"}
-        status, _, diff = gh._Github__requester.requestBlob(  # type: ignore
-            "GET", pr.url, headers=headers
-        )
-
-        if status != 200:
-            print_error(f"Failed to get PR diff ({status})")
-            raise typer.Exit(1)
-
-        pr_diff_str = f"PR diff:\n{diff}"
 
     prompt = HumanMessage(
         content=f"""
-        Provide a description for the PR {pr_location}.
+        Provide a description for the PR diff below.
 
         Be concise and informative about the contents of the PR, relevant to someone
         reviewing the PR. Write the description the following format:
         {template}
 
         PR body:
-        {pr.body}
+        {body}
 
-        {pr_diff_str}
+        {diff}
         """
     )
 
@@ -85,10 +73,12 @@ def generate_description(
 
 
 def generate_ticket(
-    ai_prompt: str,
-    issuetype: str,
     repo_name: str | None,
     chat_provider: ChatProvider | None,
+    issuetype: str | None = None,
+    issuetypes: list[str] | None = None,
+    ai_prompt: str | None = None,
+    pr_description: str | None = None,
     requested_changes: str | None = None,
     previous_attempt: TicketGeneration | None = None,
     previous_error: str | None = None,
@@ -101,6 +91,21 @@ def generate_ticket(
     chat = _get_chat_model(chat_provider)
     if not chat:
         raise typer.Exit(1)
+
+    if ai_prompt:
+        context = f"user prompt: {ai_prompt}."
+    elif pr_description:
+        context = f"PR description:\n{pr_description}."
+    else:
+        print_error("No context provided to generate ticket.")
+        raise typer.Exit(1)
+
+    if not issuetype:
+        if not issuetypes:
+            print_error("No issuetype provided when generating ticket without provided issuetype.")
+            raise typer.Exit(1)
+
+        issuetype = _generate_issuetype(chat, issuetypes, context)
 
     default_template = """
     Description:
@@ -116,6 +121,7 @@ def generate_ticket(
         "description": "{ticket description}",
         "summary": "{ticket summary, 15 words or less}",
     }
+
     error = f"Error on previous attempt: {previous_error}" if previous_error else ""
     changes = (
         f"Requested changes from previous generation: {requested_changes}\n\n{
@@ -131,7 +137,7 @@ def generate_ticket(
         {changes}
 
         Provide a description and summary for a Jira {issuetype} ticket
-        given the user prompt: {ai_prompt}.
+        given the {context}.
 
         The summary should be as specific as possible to the goal of the ticket.
 
@@ -152,38 +158,31 @@ def generate_ticket(
 
     try:
         parsed = json.loads(response.content)  # type: ignore
-        if not parsed.get("description") or not parsed.get("summary"):
+        return TicketGeneration.model_validate(parsed | {"issuetype": issuetype})
+    except (JSONDecodeError, ValidationError) as err:
+        if isinstance(err, JSONDecodeError):
             error = (
-                f"Your response was in invalid format ({parsed}). Make sure it is in format of: "
+                f"Your response was not in valid JSON format. Make sure it is in format of: "
                 f"{json.dumps(response_format)}"
             )
-            return generate_ticket(
-                ai_prompt,
-                issuetype,
-                repo_name,
-                chat_provider,
-                requested_changes,
-                previous_attempt,
-                error,
-                retry + 1,
+        else:
+            error = (
+                f"Your response was in invalid format. Make sure it is in format of: "
+                f"{json.dumps(response_format)}. Error: {err}"
             )
-    except JSONDecodeError:
-        error = (
-            f"Your response was not in valid JSON format. Make sure it is in format of: "
-            f"{json.dumps(response_format)}"
-        )
+
         return generate_ticket(
-            ai_prompt,
-            issuetype,
             repo_name,
             chat_provider,
+            issuetype,
+            issuetypes,
+            ai_prompt,
+            pr_description,
             requested_changes,
             previous_attempt,
             error,
             retry + 1,
         )
-
-    return TicketGeneration.model_validate(parsed)
 
 
 def prompt_for_chat_provider(
@@ -211,7 +210,101 @@ def prompt_for_chat_provider(
     if len(providers) == 1:
         return providers[0]
 
+    if PREFERENCES.preferred_provider in providers:
+        return PREFERENCES.preferred_provider
+
     return inquirer.select("Select provider:", providers).execute()
+
+
+def generate_commit_message(
+    chat_provider: ChatProvider | None,
+    diff: str,
+    error: str | None = None,
+    retry: int = 0,
+) -> CommitGeneration:
+    if retry > 2:
+        print_error(f"Failed to generate commit after {retry} attempts")
+        raise typer.Exit(1)
+
+    if not chat_provider:
+        print_error("Can't generate commit message with no API key")
+        raise typer.Exit(1)
+
+    response_format = {
+        "title": "{commit title}",
+        "type": "{conventional commit type}",
+        "body": "{commit body, bullet-pointed list}",
+    }
+
+    prompt = HumanMessage(
+        content=f"""
+        {error}
+
+        Provide a commit message for the following diff:
+        {diff}
+
+        Be concise in the body, using bullets to give a high level summary. Limit
+        to 5 bullets.
+
+        Your response should be in format of {json.dumps(response_format)}
+        """
+    )
+
+    chat = _get_chat_model(chat_provider)
+
+    response = chat.invoke([prompt])  # type: ignore
+
+    try:
+        parsed = json.loads(response.content)  # type: ignore
+        return CommitGeneration.model_validate(parsed)
+    except (JSONDecodeError, ValidationError) as err:
+        if isinstance(err, JSONDecodeError):
+            error = (
+                f"Your response was not in valid JSON format. Make sure it is in format of: "
+                f"{json.dumps(response_format)}"
+            )
+        else:
+            error = (
+                f"Your response was in invalid format. Make sure it is in format of: "
+                f"{json.dumps(response_format)}. Error: {err}"
+            )
+
+        return generate_commit_message(chat_provider, diff, error, retry + 1)
+
+
+def _generate_issuetype(
+    chat: BaseChatModel,
+    issuetypes: list[str],
+    context: str,
+    error: str | None = None,
+    retry: int = 0,
+) -> str:
+    if retry > 2:
+        print_error(f"Failed to generate issuetype after {retry} attempts")
+        raise typer.Exit(1)
+
+    issuetypes_str = ", ".join(f"'{issuetype}'" for issuetype in issuetypes)
+
+    prompt = HumanMessage(
+        content=f"""
+        {error}
+
+        Provide the issue type for a Jira ticket
+        given the {context}.
+
+        The issue type should be one of: {issuetypes_str}.
+
+        Your response should be simply the issue type, NOTHING else.
+        """
+    )
+
+    response = chat.invoke([prompt])
+
+    if response.content in (issuetypes or []):
+        return response.content  # type: ignore
+
+    error = f"Invalid issuetype: {response.content}. Should be one of: {issuetypes_str}."
+    return _generate_issuetype(chat, issuetypes, context, error, retry + 1)
 
 
 def _get_chat_model(provider: ChatProvider | None) -> BaseChatModel | None:

--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -27,8 +27,8 @@ def main(
         typer.echo(ctx.get_help())
 
 
-app.add_typer(pr.app, name="pr")
-app.add_typer(ticket.app, name="ticket")
+app.add_typer(pr.app, name="pr", help="Interact with pull requests.")
+app.add_typer(ticket.app, name="ticket", help="Interact with Jira tickets.")
 
 if __name__ == "__main__":
     app()

--- a/glu/cli/pr.py
+++ b/glu/cli/pr.py
@@ -1,12 +1,17 @@
+import re
 from typing import Annotated
 
 import rich
 import typer
 from git import Commit, GitCommandError, InvalidGitRepositoryError
 from github import Auth, Github, GithubException
+from InquirerPy import inquirer
 from jira import JIRA
 
-from glu.ai import generate_description, prompt_for_chat_provider
+from glu.ai import (
+    generate_description,
+    prompt_for_chat_provider,
+)
 from glu.config import (
     EMAIL,
     GITHUB_PAT,
@@ -16,13 +21,22 @@ from glu.config import (
     JIRA_SERVER,
 )
 from glu.gh import prompt_for_reviewers
-from glu.git import (
+from glu.jira import (
+    create_ticket,
+    format_jira_ticket,
+    generate_ticket_with_ai,
+    get_jira_issuetypes,
+    get_jira_project,
+    get_user_from_jira,
+)
+from glu.local import (
+    create_commit,
+    generate_commit_with_ai,
     get_first_commit_since_checkout,
     get_repo,
     get_repo_name,
     remote_branch_in_sync,
 )
-from glu.jira import format_jira_ticket, get_jira_project
 from glu.utils import (
     print_error,
 )
@@ -30,11 +44,11 @@ from glu.utils import (
 app = typer.Typer()
 
 
-@app.command(short_help="Create a PR with description and transition JIRA ticket")
+@app.command(short_help="Create a PR with description")
 def create(  # noqa: C901
     ticket: Annotated[
         str | None,
-        typer.Option("--ticket", "-t", help="Jira ticket number", prompt=True),
+        typer.Option("--ticket", "-t", help="Jira ticket number"),
     ] = None,
     project: Annotated[
         str | None,
@@ -63,26 +77,56 @@ def create(  # noqa: C901
     ] = None,
 ):
     try:
-        git = get_repo()
-        repo_name = get_repo_name(git)
+        local_repo = get_repo()
+        repo_name = get_repo_name(local_repo)
     except InvalidGitRepositoryError as err:
         print_error("Not valid a git repository")
         raise typer.Exit(1) from err
 
-    if git.is_dirty():
-        typer.confirm("You have uncommitted changes. Proceed with PR creation?", abort=True)
+    chat_provider = prompt_for_chat_provider(provider)
+
+    latest_commit: Commit | None = None
+    if local_repo.is_dirty():
+        commit_choice = inquirer.select(
+            "You have uncommitted changes.",
+            [
+                "Commit and push with AI message",
+                "Commit and push with manual message",
+                "Proceed anyway",
+            ],
+        ).execute()
+        match commit_choice:
+            case "Commit and push with AI message":
+                rich.print("[grey70]Generating commit...[/]\n")
+                commit_data = generate_commit_with_ai(chat_provider, local_repo)
+
+                latest_commit = create_commit(local_repo, commit_data.message)
+                local_repo.git.push("origin", local_repo.active_branch.name)
+            case "Commit and push with manual message":
+                commit_message = typer.edit("")
+                if not commit_message:
+                    print_error("No commit message provided")
+                    raise typer.Exit(0)
+
+                latest_commit = create_commit(local_repo, commit_message)
+                local_repo.git.push("origin", local_repo.active_branch.name)
+            case "Proceed anyway":
+                pass
+            case _:
+                print_error("No matching choice for commit was provided")
+                raise typer.Exit(1)
 
     try:
-        git.remotes["origin"].fetch(git.active_branch.name, prune=True)
+        local_repo.remotes["origin"].fetch(local_repo.active_branch.name, prune=True)
     except GitCommandError:
-        git.git.push("origin", git.active_branch.name)
+        local_repo.git.push("origin", local_repo.active_branch.name)
 
-    if not remote_branch_in_sync(git.active_branch.name, repo=git):
+    if not remote_branch_in_sync(local_repo.active_branch.name, repo=local_repo):
         confirm_push = typer.confirm(
             "Local branch is not up to date with remote. Push to remote now?"
         )
         if confirm_push:
-            git.git.push("origin", git.active_branch.name)
+            local_repo.git.push("origin", local_repo.active_branch.name)
 
     auth = Auth.Token(GITHUB_PAT)
     gh = Github(auth=auth)
@@ -92,21 +136,62 @@ def create(  # noqa: C901
     repo = gh.get_repo(repo_name)
 
     first_commit = get_first_commit_since_checkout()
+    commit = latest_commit or first_commit
 
-    jira_key = get_jira_project(jira, repo_name, project) if ticket else ""
+    jira_project = get_jira_project(jira, repo_name, project) if ticket else ""
 
-    title = first_commit.summary
-    body = _create_pr_body(first_commit, jira_key, ticket)
+    title = (
+        first_commit.summary.decode()
+        if isinstance(first_commit.summary, bytes)
+        else first_commit.summary
+    )
+    body = _create_pr_body(commit, jira_project, ticket)
 
     selected_reviewers = prompt_for_reviewers(gh, reviewers, repo_name, draft)
 
-    chat_provider = prompt_for_chat_provider(provider)
+    rich.print("[grey70]Generating description...[/]")
+    pr_description = generate_description(repo, local_repo, body, chat_provider, jira_project)
+
+    if not ticket:
+        ticket_choice = typer.prompt(
+            "Ticket [enter #, enter (g) to generate, or Enter to skip]",
+            default="",
+            show_default=False,
+        )
+        if ticket_choice.lower() == "g":
+            jira_project = jira_project or get_jira_project(jira, repo_name, project)
+            rich.print("[grey70]Generating ticket...[/]")
+
+            issuetypes = get_jira_issuetypes(jira, jira_project)
+            ticket_data = generate_ticket_with_ai(
+                repo_name, chat_provider, issuetypes=issuetypes, pr_description=pr_description
+            )
+
+            myself_ref = get_user_from_jira(jira, user_query=None)
+
+            jira_issue = create_ticket(
+                jira,
+                jira_project,
+                ticket_data.issuetype,
+                ticket_data.summary,
+                ticket_data.description,
+                myself_ref,
+                myself_ref,
+            )
+            ticket = jira_issue.key.split("-")[1]
+        elif ticket_choice.isdigit():
+            ticket = ticket_choice
+        else:
+            return
+
+    if pr_description and ticket and jira_project:
+        pr_description = _add_jira_key_to_description(pr_description, jira_project, ticket)
 
     pr = repo.create_pull(
         repo.default_branch,
-        git.active_branch.name,
+        local_repo.active_branch.name,
         title=title,
-        body=body or "",
+        body=pr_description or body or "",
         draft=draft,
     )
     pr.add_to_assignees(gh.get_user().login)
@@ -118,11 +203,6 @@ def create(  # noqa: C901
             except GithubException as e:
                 print_error(f"Failed to add reviewer {selected_reviewer.login}: {e}")
 
-    rich.print("[grey70]Generating description...[/]")
-    pr_description = generate_description(gh, repo, pr, chat_provider)
-    if pr_description:
-        pr.edit(body=pr_description)
-
     rich.print(f"\n[grey70]{pr_description}[/]\n")
     rich.print(f":rocket: Created PR in [blue]{repo_name}[/] with title [bold green]{title}[/]")
     rich.print(f"[dark violet]https://github.com/{repo_name}/pull/{pr.number}[/]")
@@ -130,7 +210,7 @@ def create(  # noqa: C901
     if not ticket:
         return
 
-    ticket_id = format_jira_ticket(jira_key, ticket)
+    ticket_id = format_jira_ticket(jira_project, ticket or "")
 
     transitions = [transition["name"] for transition in jira.transitions(ticket_id)]
 
@@ -167,3 +247,27 @@ def _create_pr_body(commit: Commit, jira_key: str, ticket: str | None) -> str | 
         return body
 
     return body.replace(ticket, f"[{ticket_str}]")
+
+
+def _add_jira_key_to_description(text: str, jira_project: str, jira_key: str | int) -> str:
+    """
+    Search for any substring matching [{jira_project}-NUMBERS/LETTERS] (e.g. [ABC-XX1234] or ABC-XX1234)
+    and replace each occurrence with the formatted Jira key.
+
+    Args:
+        text: The input string to search.
+        jira_key: The Jira key to substitute in place of each [...] match.
+
+    Returns:
+        A new string with all [LETTERS-NUMBERS] patterns replaced.
+    """
+    pattern = rf"\[?{jira_project}-[A-Za-z0-9]+\]?"
+    formatted_key = format_jira_ticket(jira_project, jira_key)
+
+    if formatted_key in text:
+        return text  # already present
+
+    if re.search(pattern, text) is not None:
+        return re.sub(pattern, formatted_key, text)
+
+    return f"{text}\n\n{jira_key}"

--- a/glu/cli/ticket.py
+++ b/glu/cli/ticket.py
@@ -7,12 +7,17 @@ from InquirerPy import inquirer
 from jira import JIRA
 from typer import Context
 
-from glu.ai import generate_ticket, prompt_for_chat_provider
+from glu.ai import prompt_for_chat_provider
 from glu.config import DEFAULT_JIRA_PROJECT, EMAIL, JIRA_API_TOKEN, JIRA_SERVER
-from glu.git import get_repo_name
-from glu.jira import get_jira_project, get_user_from_jira
-from glu.models import ChatProvider, TicketGeneration
-from glu.utils import get_kwargs, print_error, prompt_or_edit
+from glu.jira import (
+    create_ticket,
+    generate_ticket_with_ai,
+    get_jira_issuetypes,
+    get_jira_project,
+    get_user_from_jira,
+)
+from glu.local import get_repo_name
+from glu.utils import get_kwargs, prompt_or_edit
 
 app = typer.Typer()
 
@@ -67,7 +72,7 @@ def create(
     if not project:
         project = get_jira_project(jira, repo_name)
 
-    types = [issuetype.name for issuetype in jira.issue_types_for_project(project or "")]
+    types = get_jira_issuetypes(jira, project or "")
     if not type:
         issuetype = inquirer.select("Select type:", types).execute()
     else:
@@ -83,10 +88,10 @@ def create(
         # if isinstance(ai_prompt, bool):
         #     prompt = prompt_or_edit('AI Prompt')
         # else:
-        prompt = ai_prompt
+        # prompt = ai_prompt
 
         provider = prompt_for_chat_provider(provider, True)
-        ticket_data = _generate_with_ai_prompt(prompt, provider, issuetype, repo_name)
+        ticket_data = generate_ticket_with_ai(repo_name, provider, issuetype, ai_prompt=ai_prompt)
         summary = ticket_data.summary
         body = ticket_data.description
     else:
@@ -99,84 +104,16 @@ def create(
         if not body:
             body = prompt_or_edit("Description", allow_skip=True)
 
-    reporter_id = get_user_from_jira(jira, reporter)
+    reporter_ref = get_user_from_jira(jira, reporter)
 
-    assignee_id = get_user_from_jira(jira, assignee)
+    assignee_ref = get_user_from_jira(jira, assignee)
 
     if priority:
         extra_fields["priority"] = priority
 
-    fields = extra_fields | {
-        "project": project,
-        "issuetype": issuetype,
-        "description": body,
-        "summary": summary,
-        "reporter": reporter_id,
-        "assignee": assignee_id,
-    }
-
-    issue = jira.create_issue(fields)
+    issue = create_ticket(
+        jira, project, issuetype, summary or "", body, reporter_ref, assignee_ref, **extra_fields
+    )
 
     rich.print(f":page_with_curl: Created issue [bold red]{issue.key}[/]")
     rich.print(f"View at {issue.permalink()}")
-
-
-def _generate_with_ai_prompt(
-    ai_prompt: str,
-    provider: ChatProvider | None,
-    issuetype: str,
-    repo_name: str | None,
-    requested_changes: str | None = None,
-    previous_attempt: TicketGeneration | None = None,
-) -> TicketGeneration:
-    ticket_data = generate_ticket(
-        ai_prompt, issuetype, repo_name, provider, requested_changes, previous_attempt
-    )
-    summary = ticket_data.summary
-    body = ticket_data.description
-
-    rich.print(f"[grey70]Proposed summary:[/]\n{summary}\n")
-    rich.print(f"[grey70]Proposed description:[/]\n{body}")
-
-    proceed_choice = inquirer.select(
-        "How would you like to proceed?",
-        ["Accept", "Edit", "Ask for changes", "Amend prompt and regenerate", "Exit"],
-    ).execute()
-
-    match proceed_choice:
-        case "Accept":
-            return ticket_data
-        case "Edit":
-            edited = typer.edit(f"Summary: {summary}\n\nDescription: {body}")
-            if edited is None:
-                print_error("No description provided")
-                raise typer.Exit(1)
-            summary = edited.split("\n\n")[0].replace("Summary:", "").strip()
-            body = edited.split("\n\n")[1].replace("Description:", "").strip()
-            return TicketGeneration(description=body, summary=summary)
-        case "Ask for changes":
-            requested_changes = typer.edit("")
-            if requested_changes is None:
-                print_error("No changes requested.")
-                raise typer.Exit(1)
-            return _generate_with_ai_prompt(
-                ai_prompt,
-                provider,
-                issuetype,
-                repo_name,
-                requested_changes,
-                ticket_data,
-            )
-        case "Amend prompt and regenerate":
-            amended_prompt = typer.edit(ai_prompt)
-            if amended_prompt is None:
-                print_error("No prompt provided.")
-                raise typer.Exit(1)
-            return _generate_with_ai_prompt(
-                amended_prompt,
-                provider,
-                issuetype,
-                repo_name,
-            )
-        case _:
-            raise typer.Exit(0)

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -1,16 +1,19 @@
+import rich
 import typer
 from InquirerPy import inquirer
 from InquirerPy.base import Choice
-from jira import JIRA
+from jira import JIRA, Issue
 
+from glu.ai import generate_ticket
 from glu.config import REPO_CONFIGS
+from glu.models import ChatProvider, IdReference, TicketGeneration
 from glu.utils import filterable_menu, print_error
 
 
-def get_user_from_jira(jira: JIRA, user_query: str | None) -> dict[str, str]:
+def get_user_from_jira(jira: JIRA, user_query: str | None) -> IdReference:
     myself = jira.myself()
-    if not user_query or user_query in ["me@me"]:
-        return {"id": myself["accountId"]}
+    if not user_query or user_query in ["me", "@me"]:
+        return IdReference(id=myself["accountId"])
 
     users = jira.search_users(query=user_query)
     if not len(users):
@@ -18,14 +21,14 @@ def get_user_from_jira(jira: JIRA, user_query: str | None) -> dict[str, str]:
         raise typer.Exit(1)
 
     if len(users) == 1:
-        return {"id": users[0].accountId}
+        return IdReference(id=users[0].accountId)
 
     choice = inquirer.select(
         "Select reporter:",
         choices=[Choice(user.accountId, user.displayName) for user in users],
     ).execute()
 
-    return {"id": choice}
+    return IdReference(id=choice)
 
 
 def get_jira_project(jira: JIRA, repo_name: str | None, project: str | None = None) -> str:
@@ -37,17 +40,126 @@ def get_jira_project(jira: JIRA, repo_name: str | None, project: str | None = No
     if project and project.upper() in [project.key for project in projects]:
         return project.upper()
 
-    selected_project = filterable_menu("Select project: ", project_keys)
-    return selected_project
+    return filterable_menu("Select project: ", project_keys)
+
+
+def get_jira_issuetypes(jira: JIRA, project: str) -> list[str]:
+    return [issuetype.name for issuetype in jira.issue_types_for_project(project)]
 
 
 def format_jira_ticket(jira_key: str, ticket: str | int) -> str:
     try:
         ticket_num = int(ticket)
     except ValueError as err:
-        print_error(
-            "Jira ticket must be an integer. Provide the Jira project key via the config.toml file"
-        )
+        print_error("Jira ticket must be an integer.")
         raise typer.Exit(1) from err
 
     return f"{jira_key}-{ticket_num}"
+
+
+def generate_ticket_with_ai(
+    repo_name: str | None,
+    chat_provider: ChatProvider | None,
+    issuetype: str | None = None,
+    issuetypes: list[str] | None = None,
+    ai_prompt: str | None = None,
+    pr_description: str | None = None,
+    requested_changes: str | None = None,
+    previous_attempt: TicketGeneration | None = None,
+) -> TicketGeneration:
+    ticket_data = generate_ticket(
+        repo_name,
+        chat_provider,
+        issuetype,
+        issuetypes,
+        ai_prompt,
+        pr_description,
+        requested_changes,
+        previous_attempt,
+    )
+    summary = ticket_data.summary
+    body = ticket_data.description
+
+    rich.print(f"[grey70]Proposed summary:[/]\n{summary}\n")
+    rich.print(f"[grey70]Proposed description:[/]\n{body}")
+
+    choices = [
+        "Accept",
+        "Edit",
+        "Ask for changes",
+        f"{'Amend' if ai_prompt else 'Add'} prompt and regenerate",
+        "Exit",
+    ]
+
+    proceed_choice = inquirer.select(
+        "How would you like to proceed?",
+        choices,
+    ).execute()
+
+    match proceed_choice:
+        case "Accept":
+            return ticket_data
+        case "Edit":
+            edited = typer.edit(f"Summary: {summary}\n\nDescription: {body}")
+            if edited is None:
+                print_error("No description provided")
+                raise typer.Exit(1)
+            summary = edited.split("\n\n")[0].replace("Summary:", "").strip()
+            body = edited.split("\n\n")[1].replace("Description:", "").strip()
+            return TicketGeneration(
+                description=body, summary=summary, issuetype=ticket_data.issuetype
+            )
+        case "Ask for changes":
+            requested_changes = typer.edit("")
+            if requested_changes is None:
+                print_error("No changes requested.")
+                raise typer.Exit(1)
+            return generate_ticket_with_ai(
+                repo_name,
+                chat_provider,
+                issuetype,
+                issuetypes,
+                ai_prompt,
+                pr_description,
+                requested_changes,
+                ticket_data,
+            )
+        case s if s.endswith("prompt and regenerate"):
+            amended_prompt = typer.edit(ai_prompt or "")
+            if amended_prompt is None:
+                print_error("No prompt provided.")
+                raise typer.Exit(1)
+            return generate_ticket_with_ai(
+                repo_name,
+                chat_provider,
+                issuetype,
+                issuetypes,
+                amended_prompt,
+                pr_description,
+                requested_changes,
+                ticket_data,
+            )
+        case _:
+            raise typer.Exit(0)
+
+
+def create_ticket(
+    jira: JIRA,
+    project: str,
+    issuetype: str,
+    summary: str,
+    description: str | None,
+    reporter_ref: IdReference,
+    assignee_ref: IdReference,
+    **extra_fields: dict,
+) -> Issue:
+    fields = extra_fields | {
+        "project": project,
+        "issuetype": issuetype,
+        "description": description,
+        "summary": summary,
+        "reporter": reporter_ref.model_dump(),
+        "assignee": assignee_ref.model_dump(),
+    }
+
+    return jira.create_issue(fields)

--- a/glu/local.py
+++ b/glu/local.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 
+import rich
 import typer
-from git import GitCommandError, Repo
+from git import Commit, GitCommandError, HookExecutionError, Repo
+from InquirerPy import inquirer
 
+from glu.ai import generate_commit_message
+from glu.config import PREFERENCES
+from glu.models import ChatProvider, CommitGeneration
 from glu.utils import print_error
 
 
@@ -22,7 +27,7 @@ def get_repo() -> Repo:
     return Repo(cwd, search_parent_directories=True)
 
 
-def get_first_commit_since_checkout(repo: Repo | None = None):
+def get_first_commit_since_checkout(repo: Repo | None = None) -> Commit:
     """
     Return the first commit made on the current branch since it was last checked out.
     If no new commits have been made, returns None.
@@ -83,3 +88,57 @@ def remote_branch_in_sync(
     remote_sha = repo.refs[remote_ref_name].commit.hexsha
 
     return local_sha == remote_sha
+
+
+def get_git_diff(repo: Repo | None = None) -> str:
+    repo = repo or get_repo()
+    return repo.git.diff("HEAD")
+
+
+def generate_commit_with_ai(
+    chat_provider: ChatProvider | None,
+    local_repo: Repo,
+) -> CommitGeneration:
+    diff = get_git_diff(local_repo)
+    commit_data = generate_commit_message(chat_provider, diff)
+
+    if PREFERENCES.auto_accept_generated_commits:
+        return commit_data
+
+    rich.print(f"[grey70]Proposed commit:[/]\n{commit_data.message}\n")
+
+    choices = ["Accept", "Edit", "Exit"]
+
+    proceed_choice = inquirer.select(
+        "How would you like to proceed?",
+        choices,
+    ).execute()
+
+    match proceed_choice:
+        case "Accept":
+            return commit_data
+        case "Edit":
+            edited = typer.edit(commit_data.message)
+            if edited is None:
+                print_error("No description provided")
+                raise typer.Exit(1)
+            title_with_type = edited.split("\n\n")[0].strip()
+            body = edited.split("\n\n")[1].strip()
+            return CommitGeneration(
+                title=title_with_type.split(":")[1], body=body, type=title_with_type.split(":")[0]
+            )
+        case _:
+            raise typer.Exit(0)
+
+
+def create_commit(local_repo: Repo, message: str, retry: int = 0) -> Commit:
+    try:
+        local_repo.git.add(all=True)
+        return local_repo.index.commit(message)
+    except HookExecutionError as err:
+        if retry == 0:
+            rich.print("[warning]Pre-commit hooks failed, retrying...[/]")
+            return create_commit(local_repo, message, retry + 1)
+
+        rich.print(err)
+        raise typer.Exit(1) from err

--- a/glu/models.py
+++ b/glu/models.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from github.NamedUser import NamedUser
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 ChatProvider = Literal["OpenAI", "Glean"]
 
@@ -18,3 +18,26 @@ class MatchedUser:
 class TicketGeneration(BaseModel):
     description: str
     summary: str
+    issuetype: str
+
+
+class IdReference(BaseModel):
+    id: str
+
+
+class CommitGeneration(BaseModel):
+    title: str
+    body: str
+    type: str
+
+    @model_validator(mode="after")
+    def validate_title(self) -> "CommitGeneration":
+        if self.type in self.title:
+            self.title = self.title.replace(f"{self.type}:", "").strip()
+
+        self.title = self.title.capitalize()
+        return self
+
+    @property
+    def message(self):
+        return f"{self.type}: {self.title}\n\n{self.body}"


### PR DESCRIPTION
### Description

- **Jira Ticket**: GLU-10  
- **Summary**:  
  Adds AI-driven commit message and Jira ticket generation, refactors local Git handling, and streamlines PR/ticket CLI flows.  
- **Implementation details**:  
  - Introduce `generate_commit_message` + `CommitGeneration` model to propose conventional commit messages from diffs  
  - Migrate Git operations from custom `glu.git` to `git.Repo` in new `glu/local.py`; remove old module  
  - Extend `generate_ticket` to accept PR context or freeform prompt, auto-select issuetype with `_generate_issuetype`, paginate prompts, and retry on parse errors  
  - Add `generate_ticket_with_ai` in `glu/jira.py` with interactive Accept/Edit/Regenerate loop  
  - Integrate AI commit generation into `pr create` flow: prompt on dirty working tree, commit via AI or manual, push before PR creation  
  - Enhance `pr create` to optionally generate a Jira ticket if none provided (`(g)enerate`), post-process PR description to inject JIRA links  
  - Update CLI command help texts and unify prompt logic in `pr` and `ticket` subcommands  
  - Add `Preferences` to config (`PREFERENCES`) for default AI provider and auto-accept commits  
  - Improve Jira utilities: `get_jira_issuetypes`, `create_ticket`, `IdReference` model, `format_jira_ticket`, plus `_add_jira_key_to_description`  

### Changes

- **glu/ai.py**  
  - New `generate_commit_message`, extended `generate_ticket`, switch to `git.Repo` for diffs, add issuetype auto-selection and retry logic  
- **glu/local.py** (formerly `glu/git.py`)  
  - Local Git helpers: `get_git_diff`, `generate_commit_with_ai`, `create_commit`, commit hook retry  
- **glu/jira.py**  
  - `generate_ticket_with_ai` wrapper for interactive ticket review  
  - New `get_jira_issuetypes`, `create_ticket`, `IdReference` support, and PR-description post-processing  
- **glu/cli/pr.py**  
  - Prompt workflow for uncommitted changes → AI or manual commit  
  - Pre-push sync checks, use AI for PR description and optional AI-driven ticket creation  
  - Inject formatted Jira key into PR body  
- **glu/cli/ticket.py**  
  - Replace in-PR ticket AI logic with shared `generate_ticket_with_ai` helper  
  - Simplified field collection, unified create path  
- **glu/config.py**  
  - Add `Preferences` model + global `PREFERENCES` instance for defaults  
- **glu/models.py**  
  - Add `CommitGeneration`, extend `TicketGeneration` with `issuetype`, add `IdReference`, validation hooks  
- **CLI entrypoint**  
  - Improved help texts for `pr` and `ticket` commands  

### Test Plan

1. Configure an AI provider (OpenAI or Glean) API key in `config.toml`.  
2. On a dirty repo, invoke `glu pr create`; verify commit generation, edit/accept flows, push, PR creation with generated description.  
3. Test `glu pr create --ticket` and choose `(g)enerate` to auto-create a Jira issue; confirm correct issue fields, transitions, and PR body link.  
4. Test `glu ticket create --ai-prompt "<text>"`; verify interactive summary/description loop.  
5. Verify fallback to manual flows when AI is disabled or errors occur.  

### Dependencies

- New:  
  - pydantic validation for new models  
  - GitPython (already present) used in more places  
  - InquirerPy for interactive loops  
- Removed: old `glu.git` module  

### Future Enhancements / Open questions / Risks / Technical Debt

- Add unit tests for AI-assist functions (`generate_commit_message`, `generate_ticket`) and CLI flows  
- Consider capping diff size or streaming for very large repos  
- Expose retry limits and prompt templates in user config  
- Handle multi-branch workflows or monorepo ticket patterns  

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] If necessary, documentation has been updated.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself, to guide reviewers and future coders through my changes and the intended results.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken to not necessitate backward compatibility.