### PR TITLE
feat: Interactive config init, dry-run commits & config refactor

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,21 @@
+name: "Validate PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/glu/ai.py
+++ b/glu/ai.py
@@ -244,7 +244,7 @@ def generate_commit_message(
         {diff}
 
         Be concise in the body, using bullets to give a high level summary. Limit
-        to 5 bullets.
+        to 5 bullets. Focus on the code. Don't mention version bumps of the package itself.
 
         Your response should be in format of {json.dumps(response_format)}
         """

--- a/glu/cli/init.py
+++ b/glu/cli/init.py
@@ -1,8 +1,0 @@
-import typer
-
-app = typer.Typer()
-
-
-@app.command(short_help="Init config file")
-def init():
-    pass

--- a/glu/cli/init.py
+++ b/glu/cli/init.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer()
+
+
+@app.command(short_help="Init config file")
+def init():
+    pass

--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -1,9 +1,24 @@
+from typing import Annotated
+
+import rich
+import toml
 import typer
+from InquirerPy import inquirer
 
 from glu import __version__
 from glu.cli import pr, ticket
+from glu.config import (
+    Config,
+    EnvConfig,
+    JiraIssueTemplateConfig,
+    Preferences,
+    RepoConfig,
+    config_path,
+)
 
-app = typer.Typer()
+app = typer.Typer(rich_markup_mode="rich")
+
+DEFAULTS = EnvConfig.defaults()
 
 
 def version_callback(value: bool):
@@ -27,8 +42,224 @@ def main(
         typer.echo(ctx.get_help())
 
 
-app.add_typer(pr.app, name="pr", help="Interact with pull requests.")
-app.add_typer(ticket.app, name="ticket", help="Interact with Jira tickets.")
+@app.command(rich_help_panel=":hammer_and_wrench: Config")
+def init(
+    jira_api_token: Annotated[
+        str,
+        typer.Option(
+            help="Jira API token",
+            hide_input=True,
+            prompt="Jira API token (generate one here: "
+            "https://id.atlassian.com/manage-profile/security/api-tokens)",
+            show_default=False,
+            rich_help_panel="Jira Config",
+        ),
+    ],
+    email: Annotated[
+        str,
+        typer.Option(
+            "--jira-email",
+            "--email",
+            help="Jira email",
+            prompt="Jira email",
+            rich_help_panel="Jira Config",
+        ),
+    ],
+    github_pat: Annotated[
+        str,
+        typer.Option(
+            help="GitHub Personal Access Token",
+            hide_input=True,
+            show_default=False,
+            prompt="Github PAT (must be a classic PAT, see here: "
+            "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/"
+            "managing-your-personal-access-tokens#creating-a-personal-access-token-classic "
+            "for more info)",
+            rich_help_panel="Github Config",
+        ),
+    ],
+    openai_api_key: Annotated[
+        str,
+        typer.Option(
+            help="OpenAI API key",
+            hide_input=True,
+            prompt=True,
+            show_default=False,
+            rich_help_panel="OpenAI Config",
+        ),
+    ],
+    openai_org_id: Annotated[
+        str,
+        typer.Option(
+            help="OpenAI organization ID",
+            show_default=False,
+            prompt=True,
+            rich_help_panel="OpenAI Config",
+        ),
+    ],
+    jira_server: Annotated[
+        str, typer.Option(help="Jira server URL", prompt=True, rich_help_panel="Jira Config")
+    ] = DEFAULTS.jira_server,
+    jira_in_progress: Annotated[
+        str,
+        typer.Option(
+            help="Jira 'in progress' transition name", prompt=True, rich_help_panel="Jira Config"
+        ),
+    ] = DEFAULTS.jira_in_progress_transition,
+    jira_ready_for_review: Annotated[
+        str,
+        typer.Option(
+            help="Jira 'ready for review' transition name",
+            prompt=True,
+            rich_help_panel="Jira Config",
+        ),
+    ] = DEFAULTS.jira_ready_for_review_transition,
+    default_jira_project: Annotated[
+        str | None,
+        typer.Option(
+            help="Default Jira project key",
+            show_default=False,
+            rich_help_panel="Jira Config",
+        ),
+    ] = None,
+    glean_api_token: Annotated[
+        str | None,
+        typer.Option(
+            help="Glean API token",
+            hide_input=True,
+            show_default=False,
+            rich_help_panel="Glean Config",
+        ),
+    ] = None,
+    glean_instance: Annotated[
+        str | None,
+        typer.Option(help="Glean instance URL", show_default=False, rich_help_panel="Glean Config"),
+    ] = None,
+) -> None:
+    """
+    Initialize the Glu configuration file interactively.
+    """
+    cfg_path = config_path()
+    rich.print(f"[grey70]Config file will be written to {cfg_path}[/]")
+
+    if cfg_path.exists():
+        typer.confirm("Config file already exists. Overwrite?", default=False, abort=True)
+
+    env = EnvConfig(
+        jira_server=jira_server,
+        email=email,
+        jira_api_token=jira_api_token,
+        jira_in_progress_transition=jira_in_progress,
+        jira_ready_for_review_transition=jira_ready_for_review,
+        default_jira_project=default_jira_project or None,
+        github_pat=github_pat,
+        openai_api_key=openai_api_key or None,
+        openai_org_id=openai_org_id or None,
+        glean_api_token=glean_api_token or None,
+        glean_instance=glean_instance or None,
+    )
+
+    init_repo_config = typer.confirm(
+        "Do you want to initialize repo config?",
+        prompt_suffix=" (recommended to setup for ease-of-use):",
+    )
+    repos: dict[str, RepoConfig] = {}
+    if init_repo_config:
+        repos = _setup_repos()
+
+    init_issuetemplates = typer.confirm(
+        "Do you want to initialize templates for different Jira issue types?"
+    )
+    jira_config: dict[str, JiraIssueTemplateConfig] = {}
+    if init_issuetemplates:
+        jira_config = _setup_jira_config()
+
+    preferences = Preferences()
+    preferred_provider = inquirer.select(
+        "Preferred LLM provider?", ["None (let me pick every time)", "OpenAI", "Glean"]
+    ).execute()
+    match preferred_provider:
+        case "OpenAI":
+            preferences.preferred_provider = preferred_provider
+            if not env.openai_api_key:
+                env.openai_api_key = typer.prompt("OpenAI API Key", hide_input=True)
+            if not env.openai_org_id:
+                env.openai_org_id = typer.prompt("OpenAI Org ID", default="") or None
+        case "Glean":
+            preferences.preferred_provider = preferred_provider
+            if not env.glean_api_token:
+                env.glean_api_token = (
+                    typer.prompt("Glean API Token (ask your admin for this key)", default="")
+                    or None
+                )
+            if not env.glean_instance:
+                env.glean_instance = typer.prompt("Glean Instance")
+        case _:
+            preferences.preferred_provider = None
+
+    auto_accept_generated_commits = inquirer.select(
+        "Auto accept generated commits?", ["No", "Yes"]
+    ).execute()
+    preferences.auto_accept_generated_commits = auto_accept_generated_commits == "Yes"
+
+    config = Config(env=env, preferences=preferences, repos=repos, jira_issue=jira_config)
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(toml.dumps(config.export()), encoding="utf-8")
+
+    rich.print(f":white_check_mark: Config file written to {cfg_path}")
+
+
+def _setup_repos(
+    org_name: str | None = None, repos: dict[str, RepoConfig] | None = None
+) -> dict[str, RepoConfig]:
+    org_name = typer.prompt("Org name", default=org_name)
+    repo_name = typer.prompt("Repo name")
+
+    config = RepoConfig()
+    config.jira_project_key = typer.prompt("Jira project key")
+    add_pr_template = typer.confirm(
+        "Add PR template? (If none given, will attempt to pull PR template from repo's "
+        ".github folder or fall back to GLU's own default template)",
+        default=True,
+    )
+    if add_pr_template:
+        config.pr_template = typer.edit("")
+
+    repo = {f"{org_name}/{repo_name}": config}
+
+    setup_another = typer.confirm("Do you want to setup another repo?")
+    if setup_another:
+        return _setup_repos(org_name, (repos or {}) | repo)
+
+    return (repos or {}) | repo
+
+
+def _setup_jira_config(
+    templates: dict[str, JiraIssueTemplateConfig] | None = None,
+) -> dict[str, JiraIssueTemplateConfig]:
+    issuetype = typer.prompt("Issue type? (Generally, 'Bug', 'Story', 'Chore', etc")
+    template = typer.edit("Description:\n{description}") or "Description:\n{description}"
+
+    issuetemplate = {issuetype: JiraIssueTemplateConfig(issuetemplate=template)}
+
+    setup_another = typer.confirm("Do you want to setup another issue template?")
+    if setup_another:
+        return _setup_jira_config((templates or {}) | issuetemplate)
+
+    return (templates or {}) | issuetemplate
+
+
+app.add_typer(
+    pr.app, name="pr", help="Interact with pull requests.", rich_help_panel=":rocket: Commands"
+)
+app.add_typer(
+    ticket.app,
+    name="ticket",
+    help="Interact with Jira tickets.",
+    rich_help_panel=":rocket: Commands",
+)
+
 
 if __name__ == "__main__":
     app()

--- a/glu/cli/pr.py
+++ b/glu/cli/pr.py
@@ -219,7 +219,7 @@ def create(  # noqa: C901
 
     if JIRA_IN_PROGRESS_TRANSITION in transitions:
         jira.transition_issue(ticket_id, JIRA_IN_PROGRESS_TRANSITION)
-        transitions.append(JIRA_READY_FOR_REVIEW_TRANSITION)
+        transitions = [transition["name"] for transition in jira.transitions(ticket_id)]
 
     if not draft and ready_for_review and JIRA_READY_FOR_REVIEW_TRANSITION in transitions:
         jira.transition_issue(ticket_id, JIRA_READY_FOR_REVIEW_TRANSITION)

--- a/glu/cli/pr.py
+++ b/glu/cli/pr.py
@@ -99,11 +99,13 @@ def create(  # noqa: C901
         match commit_choice:
             case "Commit and push with AI message":
                 rich.print("[grey70]Generating commit...[/]\n")
+                create_commit(local_repo, "chore: [dry run commit]", dry_run=True)
                 commit_data = generate_commit_with_ai(chat_provider, local_repo)
 
                 latest_commit = create_commit(local_repo, commit_data.message)
                 push(local_repo)
             case "Commit and push with manual message":
+                create_commit(local_repo, "chore: [dry run commit]", dry_run=True)
                 commit_message = typer.edit("")
                 if not commit_message:
                     print_error("No commit message provided")

--- a/glu/config.py
+++ b/glu/config.py
@@ -8,7 +8,7 @@ from glu.models import ChatProvider
 
 
 class RepoConfig(BaseModel):
-    jira_key: str | None = None
+    jira_project_key: str | None = None
     pr_template: str | None = None
 
 
@@ -50,7 +50,7 @@ class Config(BaseModel):
     env: EnvConfig
     preferences: Preferences = Preferences()
     repos: dict[str, RepoConfig] = Field(default_factory=dict)
-    jira_issue_config: dict[str, JiraIssueTemplateConfig] = Field(default_factory=dict)
+    jira_issue: dict[str, JiraIssueTemplateConfig] = Field(default_factory=dict)
 
     @classmethod
     @field_validator("jira_issue_config")
@@ -58,6 +58,14 @@ class Config(BaseModel):
         cls, v: dict[str, JiraIssueTemplateConfig]
     ) -> dict[str, JiraIssueTemplateConfig]:
         return {k.lower(): data for k, data in v.items()}
+
+    def export(self) -> dict:
+        base = self.model_dump(exclude_none=True)
+        if not self.repos:
+            base.pop("repos")
+        if not self.jira_issue:
+            base.pop("jira_issue")
+        return base
 
 
 def config_path() -> Path:
@@ -90,7 +98,7 @@ ensure_config()
 config = get_config()
 
 REPO_CONFIGS = config.repos
-JIRA_ISSUE_TEMPLATES = config.jira_issue_config
+JIRA_ISSUE_TEMPLATES = config.jira_issue
 
 # jira
 JIRA_SERVER = config.env.jira_server

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -81,8 +81,8 @@ def generate_ticket_with_ai(
     summary = ticket_data.summary
     body = ticket_data.description
 
-    rich.print(f"[grey70]Proposed summary:[/]\n{summary}\n")
-    rich.print(f"[grey70]Proposed description:[/]\n{body}")
+    rich.print(f"[grey70]Proposed ticket title:[/]\n{summary}\n")
+    rich.print(f"[grey70]Proposed ticket body:[/]\n{body}")
 
     choices = [
         "Accept",

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -32,8 +32,8 @@ def get_user_from_jira(jira: JIRA, user_query: str | None) -> IdReference:
 
 
 def get_jira_project(jira: JIRA, repo_name: str | None, project: str | None = None) -> str:
-    if REPO_CONFIGS.get(repo_name or "") and REPO_CONFIGS[repo_name or ""].jira_key:
-        return REPO_CONFIGS[repo_name or ""].jira_key  # type: ignore
+    if REPO_CONFIGS.get(repo_name or "") and REPO_CONFIGS[repo_name or ""].jira_project_key:
+        return REPO_CONFIGS[repo_name or ""].jira_project_key  # type: ignore
 
     projects = jira.projects()
     project_keys = [project.key for project in projects]

--- a/glu/models.py
+++ b/glu/models.py
@@ -33,7 +33,7 @@ class CommitGeneration(BaseModel):
     @model_validator(mode="after")
     def validate_title(self) -> "CommitGeneration":
         if self.type in self.title:
-            self.title = self.title.replace(f"{self.type}:", "").strip()
+            self.title = self.title.split(":")[1].strip()
 
         self.title = self.title.capitalize()
         return self

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "glu"
-version = "1.2.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-12]  
- **Summary**:  
  This PR overhauls the CLI initialization workflow, enhances commit generation and hook handling, renames and filters config fields, and updates the AI prompt to ignore package version bumps. It also bumps the package version to 1.3.1.  
- **Implementation details**:  
  1. Updated `generate_commit_message` prompt in `glu/ai.py` to skip mentioning version bumps.  
  2. Removed `glu/cli/init.py` and consolidated all interactive setup into a new `init` command in `glu/cli/main.py`, using Typer and InquirerPy to gather EnvConfig, RepoConfig, Jira issue templates, and user preferences, then persisting to a TOML file.  
  3. Renamed config fields in `glu/config.py` (`jira_key → jira_project_key`, `jira_issue_config → jira_issue`), added an `export()` method to drop empty sections, and updated all references.  
  4. In the PR flow (`glu/cli/pr.py`), introduced a “dry-run” commit before generating or editing messages, and refined retry logic for pre-commit hooks in `glu/local.py`.  
  5. Tweaked commit title parsing in `glu/models.py` to correctly split on the first colon.  
  6. Bumped the package version in `uv.lock` to 1.3.1.

### Changes

- **glu/ai.py**:  
  - Tightened the AI commit‐message prompt to “Focus on the code. Don’t mention version bumps of the package itself.”  
- **glu/cli/main.py**:  
  - Added `init` command that interactively collects and writes configuration for Jira, GitHub, OpenAI/Glean, repositories, and issue templates to `~/.config/glu/config.toml`.  
  - Removed the old `glu/cli/init.py`.  
- **glu/cli/pr.py**:  
  - Added `dry_run=True` support in `create_commit` calls before AI- or manual-message flows.  
- **glu/config.py**:  
  - Renamed `jira_key → jira_project_key`, `jira_issue_config → jira_issue`.  
  - Added `Config.export()` to omit empty `repos` and `jira_issue` on write.  
- **glu/jira.py**:  
  - Updated project key lookup to use `jira_project_key`.  
- **glu/local.py**:  
  - Extended `create_commit()` with `dry_run` option that stashes and resets the commit during dry runs.  
  - Prevented duplicate retry warnings when in dry-run mode.  
- **glu/models.py**:  
  - Improved the title validation to split only on the first colon, then capitalize.  
- **uv.lock**:  
  - Version bumped from 1.2.0 to 1.3.1.

### Test Plan

1. Run `glu init` and verify interactive prompts save a valid TOML config.  
2. Confirm `glu pr create` with AI/manual branches still works, and that dry-run commits do not persist.  
3. Exercise pre-commit hooks failure to see retry logic.  
4. Validate generated commit messages ignore version-bump diffs.  
5. Ensure existing commands (`pr`, `ticket`, `version`) continue to function.  

### Dependencies

- New:  
  - `toml` (for config serialization)  
  - `InquirerPy` (for interactive CLI prompts)  
  - `rich` (rich text in Typer)  
- Removed:  
  - Standalone `glu/cli/init.py` (no longer needed)  

### Future Enhancements / Open questions / Risks / Technical Debt

- Migrate or backfill existing user configs created under the old schema.  
- Add automated tests covering the interactive `init` flow.  
- Consider non-interactive flags for CI usage.  
- Validate edge cases in pre-commit hook retries.  

### Checklist

- [ ] Code has been linted and adheres to coding style guidelines.  
- [ ] Tests have been added/updated for new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] No significant performance regressions introduced.  
- [ ] Documentation updated where necessary.  
- [ ] Code sufficiently commented for reviewers and future maintainers.  
- [ ] Appropriate reviewers selected.  
- [ ] Breaking changes are documented and backward compatibility is maintained or migration steps provided.

[GLU-12]: https://brightnight.atlassian.net/browse/GLU-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ