### PR TITLE
fix: Fix glu --help without config

### DIFF
--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -121,7 +121,7 @@ def init(
     cfg_path = config_path()
     rich.print(f"[grey70]Config file will be written to {cfg_path}[/]")
 
-    if cfg_path.exists():
+    if cfg_path.exists() and "your_github_pat" not in cfg_path.read_text():
         typer.confirm("Config file already exists. Overwrite?", default=False, abort=True)
 
     provider_configs = _setup_model_providers()

--- a/glu/config.py
+++ b/glu/config.py
@@ -132,9 +132,9 @@ def ensure_config():
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        default_config = {"env": EnvConfig.defaults(), "repos": {}}
+        default_config = Config(env=EnvConfig.defaults())
 
-        path.write_text(toml.dumps(default_config), encoding="utf-8")
+        path.write_text(toml.dumps(default_config.model_dump()), encoding="utf-8")
 
 
 def get_config() -> Config:


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-29]
- **Summary**:  
  Refactor configuration initialization to leverage the `Config` dataclass for serialization and improve the `init` command’s overwrite logic so placeholder configs aren’t accidentally prompted for overwrite.
- **Implementation details**:  
  • In `glu/config.py`, replace the ad‐hoc dict with a `Config(env=EnvConfig.defaults())` instance and call its `model_dump()` when writing to TOML.  
  • In `glu/cli/main.py`, change the `init` command’s existence check to only prompt for overwrite if the file exists *and* does not still contain the `"your_github_pat"` placeholder.

### Changes

- **glu/cli/main.py**  
  - Modified the `init` command’s overwrite guard to skip confirmation when the existing config still has the default GitHub PAT placeholder.
- **glu/config.py**  
  - Switched from a raw dict (`{"env":…, "repos":…}`) to constructing a `Config` dataclass for the default config.  
  - Updated file writing to use `toml.dumps(default_config.model_dump())` instead of dumping the dict directly.

### Test Plan

1. Run `glu init` with no existing config → new TOML file created with default values.  
2. Run `glu init` again when file contains `"your_github_pat"` → no overwrite prompt.  
3. Modify the PAT in the config to a real value and run `glu init` → confirm prompt appears.  
4. Validate that reading `get_config()` still returns a valid `Config` object.  

### Dependencies

- No new dependencies introduced.  
- Existing `toml` usage remains unchanged.

### Future Enhancements / Open questions / Risks / Technical Debt

- Consider migrating any other hard-coded default dict usages to dataclass models for consistency.  
- Verify backward compatibility for users who have pre-existing config files with different structures.

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] Documentation has been updated if necessary.  
- [ ] I have sufficiently commented my code to guide reviewers and future maintainers.  
- [ ] Reviewers with knowledge of the config and CLI domains have been selected.  
- [ ] Breaking changes: code maintains backward compatibility; no migration steps required for existing configs.