### PR TITLE
fix:  continue pr creation when ticket is skipped instead of returning early

### DIFF
--- a/glu/cli/pr.py
+++ b/glu/cli/pr.py
@@ -186,7 +186,7 @@ def create(  # noqa: C901
             ticket = ticket_choice
             jira_project = jira_project or get_jira_project(jira, git.repo_name, project)
         else:
-            return
+            pass
 
     if pr_description and ticket and jira_project:
         pr_description = _add_jira_key_to_description(pr_description, jira_project, ticket)

--- a/tests/test_prs.py
+++ b/tests/test_prs.py
@@ -1,5 +1,6 @@
 # ruff: noqa: ARG001, ARG002
 import re
+from typing import Literal
 
 import pexpect
 
@@ -11,30 +12,47 @@ def test_create_pr_full_flow_w_ai(write_config_w_repo_config, env_cli):
     env_cli["IS_JIRA_TICKET_IN_TO_DO"] = "1"
     child = pexpect.spawn("glu pr create", env=env_cli, encoding="utf-8")
 
+    _create_pr(child, is_git_dirty=True)
+
+
+def test_create_pr_w_no_ticket(write_config_w_repo_config, env_cli):
+    env_cli["IS_GIT_DIRTY"] = "1"
+    env_cli["IS_JIRA_TICKET_IN_TO_DO"] = "1"
+    child = pexpect.spawn("glu pr create", env=env_cli, encoding="utf-8")
+
+    _create_pr(child, is_git_dirty=True, ticket_generation="skip")
+
+
+def _create_pr(
+    child: pexpect.spawn,
+    is_git_dirty: bool = False,
+    ticket_generation: Literal["ai", "skip"] = "ai",
+):
     child.expect("Select provider:")
     child.send(Key.ENTER.value)  # select first provider
 
-    child.expect("Proceed anyway")
+    if is_git_dirty:
+        child.expect("Proceed anyway")
 
-    text = get_terminal_text(child.before + child.after)
-    assert "You have uncommitted changes" in text
-    assert "Commit and push with AI message" in text
-    assert "Commit and push with manual message" in text
-    assert "Proceed anyway" in text
+        text = get_terminal_text(child.before + child.after)
+        assert "You have uncommitted changes" in text
+        assert "Commit and push with AI message" in text
+        assert "Commit and push with manual message" in text
+        assert "Proceed anyway" in text
 
-    child.send(Key.ENTER.value)  # ai message
+        child.send(Key.ENTER.value)  # ai message
 
-    child.expect("Exit")
+        child.expect("Exit")
 
-    proposed_commit_text = get_terminal_text(child.before + child.after)
-    assert "Proposed commit:" in proposed_commit_text
-    assert "refactor: Unify client abstractions" in proposed_commit_text
-    assert "How would you like to proceed?" in proposed_commit_text
-    assert "Accept" in proposed_commit_text
-    assert "Edit" in proposed_commit_text
-    assert "Exit" in proposed_commit_text
+        proposed_commit_text = get_terminal_text(child.before + child.after)
+        assert "Proposed commit:" in proposed_commit_text
+        assert "refactor: Unify client abstractions" in proposed_commit_text
+        assert "How would you like to proceed?" in proposed_commit_text
+        assert "Accept" in proposed_commit_text
+        assert "Edit" in proposed_commit_text
+        assert "Exit" in proposed_commit_text
 
-    child.send(Key.ENTER.value)  # accept
+        child.send(Key.ENTER.value)  # accept
 
     child.expect("Select reviewers:")
     child.send(f"jack{Key.ENTER.value}")
@@ -45,29 +63,33 @@ def test_create_pr_full_flow_w_ai(write_config_w_repo_config, env_cli):
     text = get_terminal_text(child.before + child.after)
     assert "Generating description..." in text
 
-    child.send(f"g{Key.ENTER.value}")  # generate ticket
+    if ticket_generation == "ai":
+        child.send(f"g{Key.ENTER.value}")  # generate ticket
 
-    child.expect("Generating ticket...")
+        child.expect("Generating ticket...")
 
-    child.expect("Exit")
-    proposed_ticket_text = get_terminal_text(child.before + child.after)
-    assert "Proposed ticket title:" in proposed_ticket_text
-    assert "Proposed ticket body:" in proposed_ticket_text
-    assert "How would you like to proceed?" in proposed_ticket_text
-    assert "Accept" in proposed_ticket_text
-    assert "Edit" in proposed_ticket_text
-    assert "Ask for changes" in proposed_ticket_text
-    assert "Add prompt and regenerate" in proposed_ticket_text
-    assert "Exit" in proposed_ticket_text
+        child.expect("Exit")
+        proposed_ticket_text = get_terminal_text(child.before + child.after)
+        assert "Proposed ticket title:" in proposed_ticket_text
+        assert "Proposed ticket body:" in proposed_ticket_text
+        assert "How would you like to proceed?" in proposed_ticket_text
+        assert "Accept" in proposed_ticket_text
+        assert "Edit" in proposed_ticket_text
+        assert "Ask for changes" in proposed_ticket_text
+        assert "Add prompt and regenerate" in proposed_ticket_text
+        assert "Exit" in proposed_ticket_text
 
-    child.send(Key.ENTER.value)  # accept
+        child.send(Key.ENTER.value)  # accept
+    else:
+        child.send(Key.ENTER.value)
 
     child.expect(re.compile(r"https?://\S+"))
     text = get_terminal_text(child.before + child.after).strip()
 
     assert "### Description" in text
 
-    assert re.search(r"- \*\*Jira Ticket\*\*: \[TEST-\d+]", text)
+    if ticket_generation != "skip":
+        assert re.search(r"- \*\*Jira Ticket\*\*: \[TEST-\d+]", text)
 
     lines = text.splitlines()
     assert (


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-25]  
- **Summary**:  
  Change the PR creation flow so that choosing to skip ticket generation no longer aborts the command early, and add coverage for that “no ticket” path.  
- **Implementation details**:  
  - In `glu/cli/pr.py`, replace the early `return` in `create()` (when no JIRA ticket is chosen) with `pass` so execution continues to final PR output.  
  - In `tests/test_prs.py`, introduce `test_create_pr_w_no_ticket` and extend the helper `_create_pr` to accept a `ticket_generation` flag (`"ai"` or `"skip"`). Wrap AI ticket‐generation interactions and assertions behind that flag and only assert a JIRA ticket line when `"ai"` is selected.

### Changes

- **glu/cli/pr.py**  
  - create(): replace `return` with `pass` in the branch where the user opts not to create a ticket.  
- **tests/test_prs.py**  
  - Add `test_create_pr_w_no_ticket` to drive the flow with `ticket_generation="skip"`.  
  - Refactor `_create_pr` helper:  
    - Parameterize `ticket_generation` (`"ai"` vs `"skip"`) and `is_git_dirty`.  
    - Guard the “Proceed anyway” and AI‐generation expectation/assertion blocks under `is_git_dirty`.  
    - Conditionally perform the ticket‐generation prompts and assertions only when `ticket_generation == "ai"`.  
    - Only assert the presence of `- **Jira Ticket**:` in the final PR description when not skipping.

### Test Plan

1. Run the existing full‐flow PR creation test (`test_create_pr_full_flow_w_ai`) to ensure nothing regressed.  
2. Run the new `test_create_pr_w_no_ticket` to validate that skipping ticket generation still produces a valid PR description without a JIRA ticket line.  
3. No special environment variables or external dependencies beyond those already documented in CI.

### Dependencies

- Added `Literal` import from the standard `typing` module in tests.  
- No new third‐party dependencies; no removals or updates.

### Future Enhancements / Open questions / Risks / Technical Debt

- None identified. Changing the no‐ticket branch from an early exit to a no‐op should have no adverse side effects beyond this test coverage improvement.

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new flows and edge cases.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes do not introduce significant performance issues.  
- [ ] Documentation (if any) has been updated as necessary.  
- [ ] Comments added to clarify the new conditional logic.  
- [ ] Breaking changes: none (backward compatibility preserved).