### PR TITLE
feat: Add ‘generated with glu’ tag to ai-created prs and tickets

### DIFF
--- a/glu/cli/init.py
+++ b/glu/cli/init.py
@@ -35,6 +35,7 @@ def init_config(
     jira_ready_for_review: str,
     jira_done: str,
     default_jira_project: str | None,
+    generated_with_glu_tag: bool,
 ) -> None:
     cfg_path = config_path()
     rich.print(f"[grey70]Config file will be written to {cfg_path}[/]")
@@ -91,6 +92,8 @@ def init_config(
         "Auto accept generated commits?", ["No", "Yes"]
     ).execute()
     preferences.auto_accept_generated_commits = auto_accept_generated_commits == "Yes"
+
+    preferences.add_generated_with_glu_tag = generated_with_glu_tag
 
     config = Config(env=env, preferences=preferences, repos=repos, jira_issue=jira_config)
 

--- a/glu/cli/main.py
+++ b/glu/cli/main.py
@@ -108,6 +108,13 @@ def init(
             rich_help_panel="Jira Config",
         ),
     ] = None,
+    generated_with_glu_tag: Annotated[
+        bool,
+        typer.Option(
+            help="Add a tag to generated PRs and tickets to spread the word about glu!",
+            rich_help_panel="Preferences",
+        ),
+    ] = True,
 ) -> None:
     """
     Initialize the Glu configuration file interactively.
@@ -121,6 +128,7 @@ def init(
         jira_ready_for_review,
         jira_done,
         default_jira_project,
+        generated_with_glu_tag,
     )
 
 

--- a/glu/cli/pr/create.py
+++ b/glu/cli/pr/create.py
@@ -10,7 +10,7 @@ from glu.ai import (
     get_ai_client,
     prompt_for_chat_provider,
 )
-from glu.config import JIRA_IN_PROGRESS_TRANSITION, JIRA_READY_FOR_REVIEW_TRANSITION
+from glu.config import JIRA_IN_PROGRESS_TRANSITION, JIRA_READY_FOR_REVIEW_TRANSITION, PREFERENCES
 from glu.gh import get_github_client, prompt_for_reviewers
 from glu.jira import (
     format_jira_ticket,
@@ -21,7 +21,7 @@ from glu.jira import (
 )
 from glu.local import checkout_to_branch, get_git_client, prompt_commit_edit
 from glu.models import TICKET_PLACEHOLDER
-from glu.utils import print_error, suppress_traceback
+from glu.utils import add_generated_with_glu_tag, print_error, suppress_traceback
 
 
 @suppress_traceback
@@ -152,8 +152,11 @@ def create_pr(  # noqa: C901
         else:
             pass
 
-    if pr_description and ticket and jira_project:
-        pr_description = _add_jira_key_to_description(pr_description, jira_project, ticket)
+    if pr_description:
+        if ticket and jira_project:
+            pr_description = _add_jira_key_to_description(pr_description, jira_project, ticket)
+        if PREFERENCES.add_generated_with_glu_tag:
+            pr_description = add_generated_with_glu_tag(pr_description)
 
     pr = gh.create_pr(
         git.current_branch,

--- a/glu/cli/ticket/create.py
+++ b/glu/cli/ticket/create.py
@@ -6,7 +6,7 @@ from git import InvalidGitRepositoryError
 from InquirerPy import inquirer
 
 from glu.ai import get_ai_client, prompt_for_chat_provider
-from glu.config import DEFAULT_JIRA_PROJECT
+from glu.config import DEFAULT_JIRA_PROJECT, PREFERENCES
 from glu.jira import (
     generate_ticket_with_ai,
     get_jira_client,
@@ -14,7 +14,7 @@ from glu.jira import (
     get_user_from_jira,
 )
 from glu.local import get_git_client
-from glu.utils import prompt_or_edit, suppress_traceback
+from glu.utils import add_generated_with_glu_tag, prompt_or_edit, suppress_traceback
 
 
 @suppress_traceback
@@ -68,6 +68,8 @@ def create_ticket(
         )
         summary = ticket_data.summary
         body = ticket_data.description
+        if body and PREFERENCES.add_generated_with_glu_tag:
+            body = add_generated_with_glu_tag(body, supports_markdown=False)
     else:
         if not summary:
             summary = typer.prompt(

--- a/glu/config.py
+++ b/glu/config.py
@@ -97,6 +97,7 @@ class EnvConfig(BaseModel):
 class Preferences(BaseModel):
     auto_accept_generated_commits: bool = False
     preferred_provider: ChatProvider | None = None
+    add_generated_with_glu_tag: bool = True
 
 
 class Config(BaseModel):

--- a/glu/utils.py
+++ b/glu/utils.py
@@ -148,3 +148,10 @@ def suppress_traceback(func):
             raise typer.Exit(1) from err
 
     return wrapper
+
+
+def add_generated_with_glu_tag(text: str, supports_markdown: bool = True) -> str:
+    if not supports_markdown:
+        return f"{text}\n\nGenerated with [glu|https://github.com/BrightNight-Energy/glu]"
+
+    return f"{text}\n\nGenerated with [glu](https://github.com/BrightNight-Energy/glu)"


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-21]
- **Summary**:  
  Introduce a new preference and CLI option to automatically append a “Generated with glu” badge/link to created PR descriptions and Jira ticket bodies.
- **Implementation details**:  
  - Added a `generated_with_glu_tag` option to the `init` CLI and stored it in `Preferences.add_generated_with_glu_tag` (default `true`).  
  - Created `add_generated_with_glu_tag` utility that appends a markdown or plain link depending on context.  
  - Updated `glu/cli/pr/create.py` and `glu/cli/ticket/create.py` to invoke the new utility when the preference is enabled.  

### Changes

- glu/cli/init.py & glu/cli/main.py  
  - Added `--generated-with-glu-tag` flag under Preferences.  
  - Saved user choice to `preferences.add_generated_with_glu_tag`.  
- glu/config.py  
  - Introduced `add_generated_with_glu_tag: bool = True` in `Preferences`.  
- glu/utils.py  
  - Added `add_generated_with_glu_tag(text, supports_markdown: bool)` to append the badge/link.  
- glu/cli/pr/create.py  
  - If enabled, appends “Generated with glu” link to PR descriptions.  
- glu/cli/ticket/create.py  
  - If enabled, appends link to Jira ticket bodies (uses plain link when markdown isn’t supported).

### Test Plan

1. Run `glu init` and verify the new prompt under Preferences.  
2. Create a PR and a Jira ticket with the preference on/off and confirm the “Generated with glu” link appears or is omitted appropriately.

### Dependencies

- None

### Future Enhancements / Open questions / Risks / Technical Debt

- Allow customizing the tag text or URL.  
- Consider localization or formatting options for different output targets.

### Checklist

- [ ] Code has been linted and adheres to coding style guidelines.  
- [ ] Tests added/modified (or manual verification documented).  
- [ ] All FIXMEs addressed.  
- [ ] No significant performance regressions introduced.  
- [ ] Documentation updated where necessary.  
- [ ] Code sufficiently commented for reviewers.  
- [ ] Appropriate reviewers selected.  
- [ ] Breaking changes compatibility verified.

Generated with [glu](https://github.com/BrightNight-Energy/glu)