### PR TITLE
fix: Respect repo.auto branch deletion setting when squashing prs

### DIFF
--- a/glu/cli/pr/merge.py
+++ b/glu/cli/pr/merge.py
@@ -181,11 +181,13 @@ def merge_pr(  # noqa: C901
 
     rich.print("[grey70]Merging PR...[/]\n")
     try:
-        pr.merge(commit_body, commit_title, merge_method="squash", delete_branch=True)
+        pr.merge(
+            commit_body,
+            commit_title,
+            merge_method="squash",
+            delete_branch=not gh.delete_branch_on_merge,  # github will handle if True
+        )
     except GithubException as err:
-        if "Not Found" in str(err):
-            # this failure occurs if github is automatically deleting branches on merge so ignore
-            pass
         print_error(str(err))
         raise typer.Exit(1) from err
 

--- a/glu/gh.py
+++ b/glu/gh.py
@@ -87,6 +87,10 @@ class GithubClient:
         return get_all_from_paginated_list(last_commit.get_check_runs())
 
     @property
+    def delete_branch_on_merge(self) -> bool:
+        return self._repo.delete_branch_on_merge
+
+    @property
     def default_branch(self) -> str:
         return self._repo.default_branch
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,6 +308,10 @@ class FakeGithubClient:
         return TypeAdapter(list[FakeCheckRun]).validate_python(checks)  # type: ignore
 
     @property
+    def delete_branch_on_merge(self) -> bool:
+        return False
+
+    @property
     def default_branch(self) -> str:
         return "main"
 


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-39]
- **Summary**: Fix spurious “Not Found” errors when merging PRs on repos with auto-delete-branch enabled by delegating branch deletion to GitHub based on the repository setting.
- **Implementation details**:  
  - Expose the repo’s `delete_branch_on_merge` flag via a new `GithubClient.delete_branch_on_merge` property.  
  - In the CLI merge command, pass `delete_branch` as the inverse of that flag so we only delete locally when GitHub won’t.  
  - Remove the special-case swallow of a “Not Found” error and let the merge call succeed or fail appropriately.  
  - Update the fake client in tests to provide a `delete_branch_on_merge` stub.

### Changes

- glu/cli/pr/merge.py  
  • Adjusted `pr.merge(..., delete_branch=…)` to use `not gh.delete_branch_on_merge` instead of hard-coding `True`.  
- glu/gh.py  
  • Added `GithubClient.delete_branch_on_merge` property to surface `repo.delete_branch_on_merge`.  
- tests/conftest.py  
  • Implemented `delete_branch_on_merge` on `FakeGithubClient` to align tests with the new behavior.

### Test Plan

1. Verified merging a PR in a repo with auto-delete-branch enabled no longer raises a “Not Found” error.  
2. Verified merging a PR in a repo without auto-delete still deletes the branch as before.  
3. Ran full unit test suite.

### Dependencies

- None

### Future Enhancements / Open questions / Risks / Technical Debt

- No immediate follow-ups identified.

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] If necessary, documentation has been updated.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself, to guide reviewers and future coders through my changes and the intended results.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken to not necessitate backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-39]: https://brightnight.atlassian.net/browse/GLU-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ