### PR TITLE
fix: Make description optional on ticket edit

### DIFF
--- a/glu/jira.py
+++ b/glu/jira.py
@@ -155,12 +155,15 @@ def generate_ticket_with_ai(
         case "Accept":
             return ticket_data
         case "Edit":
-            edited = typer.edit(f"Summary: {summary}\n\nDescription: {body}")
+            edited = typer.edit(f"Summary: {summary}\n\nBody:\n{body}")
             if edited is None:
                 print_error("No description provided")
                 raise typer.Exit(1)
             summary = edited.split("\n\n")[0].replace("Summary:", "").strip()
-            body = edited.split("\n\n")[1].replace("Description:", "").strip()
+            try:
+                body = edited.split("\n\n")[1].replace("Body:\n", "").strip()
+            except IndexError:
+                body = ""
             return TicketGeneration(
                 description=body, summary=summary, issuetype=ticket_data.issuetype
             )


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-42]
- **Summary**: Update the interactive ticket editor to label the body section as “Body” and handle missing input gracefully
- **Implementation details**:  
  - Changed the `typer.edit` prompt from “Description” to “Body”  
  - Adjusted parsing logic to strip the “Body:\n” prefix instead of “Description:”  
  - Wrapped body extraction in a try/except to default to an empty string on missing input  
  - Left summary parsing unchanged  

### Changes

- glu/jira.py  
  - Prompt edit block now reads `Body:` instead of `Description:`  
  - After splitting on `\n\n`, the second segment is cleaned with `replace("Body:\n", "")`  
  - Added `except IndexError` around body parsing to prevent crashes when no body is provided  

### Test Plan

1. Run the AI ticket generator in “Edit” mode and verify the prompt header reads “Body”.  
2. Enter edits with and without a body section—ensure no unhandled exceptions and body defaults to empty when omitted.  
3. Confirm that the summary is still parsed correctly from the first line.  

### Dependencies

None

### Future Enhancements / Open questions / Risks / Technical Debt

- Consider adding automated tests to cover the new prompt parsing paths (body present vs. missing).  
- Evaluate if other labels (e.g. “Steps to Reproduce”) might benefit from the same pattern.  

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] If necessary, documentation has been updated.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself, to guide reviewers and future coders through my changes and the intended results.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken to not necessitate backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)