### PR TITLE
feat: Add `ticket list` command to list Jira tickets

### DIFF
--- a/glu/cli/pr/merge.py
+++ b/glu/cli/pr/merge.py
@@ -140,7 +140,7 @@ def merge_pr(  # noqa: C901
     summary_commit_message += f"\n\n{formatted_ticket}" if formatted_ticket else ""
     proposed_commit_message = (
         f"{all_commit_messages[0]}\n\n{formatted_ticket}"
-        if formatted_ticket
+        if formatted_ticket and formatted_ticket not in all_commit_messages[0]
         else all_commit_messages[0]
     )
 

--- a/glu/cli/pr/merge.py
+++ b/glu/cli/pr/merge.py
@@ -178,7 +178,7 @@ def merge_pr(  # noqa: C901
             commit_body = commit_data.body
             commit_title = commit_data.full_title
         case "Edit manually":
-            commit_msg = typer.edit(summary_commit_message)
+            commit_msg = typer.edit(proposed_commit_message)
             if not commit_msg:
                 print_error("No commit message provided")
                 raise typer.Exit(0)

--- a/glu/cli/ticket/index.py
+++ b/glu/cli/ticket/index.py
@@ -6,6 +6,7 @@ from typer import Context
 from glu.cli.ticket.create import create_ticket
 from glu.cli.ticket.list import list_tickets as list_tickets_core
 from glu.cli.ticket.open import open_ticket as open_ticket_core
+from glu.cli.ticket.view import view_ticket
 from glu.utils import get_kwargs
 
 app = typer.Typer()
@@ -114,6 +115,15 @@ def list_tickets(
             show_default=False,
         ),
     ] = None,
+    types: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--type",
+            "-t",
+            help="Filter tickets by issue type (multiple values accepted)",
+            show_default=False,
+        ),
+    ] = None,
     in_progress_only: Annotated[
         bool,
         typer.Option(
@@ -129,6 +139,7 @@ def list_tickets(
         statuses,
         order_by_priority,
         priorities,
+        types,
         in_progress_only,
         open=not show_closed,
     )
@@ -139,7 +150,12 @@ def open_ticket(
     ticket_num: Annotated[int, typer.Argument(help="Ticket number")],
     project: Annotated[str | None, typer.Option("--project", "-p", help="Jira project")] = None,
 ):
-    open_ticket_core(
-        ticket_num,
-        project,
-    )
+    open_ticket_core(ticket_num, project)
+
+
+@app.command(short_help="View Jira ticket")
+def view(
+    ticket_num: Annotated[int, typer.Argument(help="Ticket number")],
+    project: Annotated[str | None, typer.Option("--project", "-p", help="Jira project")] = None,
+):
+    view_ticket(ticket_num, project)

--- a/glu/cli/ticket/view.py
+++ b/glu/cli/ticket/view.py
@@ -1,0 +1,62 @@
+from git import InvalidGitRepositoryError
+from rich.text import Text
+
+from glu.config import DEFAULT_JIRA_PROJECT
+from glu.jira import get_color_for_priority, get_color_for_status, get_jira_client, get_jira_project
+from glu.local import get_git_client
+from glu.utils import print_panel, suppress_traceback
+
+
+@suppress_traceback
+def view_ticket(
+    ticket_num: int,
+    project: str | None,
+) -> None:
+    jira = get_jira_client()
+
+    try:
+        repo_name = get_git_client().repo_name
+    except InvalidGitRepositoryError:
+        repo_name = None
+
+    project = project or DEFAULT_JIRA_PROJECT
+    if not project:
+        jira_project = get_jira_project(jira, repo_name)
+    else:
+        jira_project = project
+
+    issue = jira.get_issue(jira_project, ticket_num)
+    fields = issue.fields
+
+    issue_text = Text("Title:\n", style="grey70")
+    issue_text.append(f"{fields.summary}\n\n", style="bright_white")
+    if fields.description:
+        issue_text.append("Body:\n")
+        issue_text.append(f"{fields.description}\n\n", style="bright_white")
+
+    priority_color = get_color_for_priority(fields.priority.name)
+    status_color = get_color_for_status(fields.status.name, fields.resolution)
+    status_style_kwarg = (
+        {"style": f"bright_white on {status_color}"}
+        if status_color != "bright_white"
+        else {"style": "bright_white"}
+    )
+
+    issue_text.append("Status: ")
+    issue_text.append(f"{fields.status.name}\n", **status_style_kwarg)
+    issue_text.append("Type: ")
+    issue_text.append(f"{fields.issuetype.name}\n", style="yellow1")
+    issue_text.append("Assignee: ")
+    issue_text.append(
+        f"{fields.assignee.displayName}\n" if fields.assignee else "[None]",
+        style="light_steel_blue",
+    )
+    issue_text.append("Reporter: ")
+    issue_text.append(
+        f"{fields.reporter.displayName}\n" if fields.reporter else "[None]",
+        style="dark_slate_gray1",
+    )
+    issue_text.append("Priority: ")
+    issue_text.append(f"{fields.priority.name}\n", style=priority_color)
+
+    print_panel(f"{jira_project}-{ticket_num}", issue_text, border_style=status_color)

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -144,7 +144,7 @@ def generate_ticket_with_ai(
 
     print_panel(
         title="Proposed ticket",
-        content=Text.from_markup(f"[grey70]Title:[/]\n{summary}\n\ngst[grey70]Body:[/]\n{body}"),
+        content=Text.from_markup(f"[grey70]Title:[/]\n{summary}\n\n[grey70]Body:[/]\n{body}"),
     )
 
     choices = [

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -5,6 +5,7 @@ import typer
 from InquirerPy import inquirer
 from InquirerPy.base import Choice
 from jira import JIRA, Issue, Project
+from jira.resources import Resolution
 from rich.text import Text
 
 from glu.ai import ChatClient, generate_ticket
@@ -59,6 +60,9 @@ class JiraClient:
 
     def search_issues(self, jql: str) -> list[Issue]:
         return self._client.search_issues(jql)
+
+    def get_issue(self, project: str, ticket_num: int) -> Issue:
+        return self._client.issue(f"{project}-{ticket_num}")
 
 
 def get_jira_client() -> JiraClient:
@@ -204,3 +208,27 @@ def generate_ticket_with_ai(
             )
         case _:
             raise typer.Exit(0)
+
+
+def get_color_for_priority(priority: str) -> str:
+    match priority.lower():
+        case "lowest":
+            return "dodger_blue3"
+        case "low":
+            return "dodger_blue1"
+        case "high":
+            return "red1"
+        case "highest":
+            return "red3"
+        case _:
+            return "bright_white"
+
+
+def get_color_for_status(status: str, resolution: Resolution | None) -> str:
+    match status.lower():
+        case "to do":
+            return "white"
+        case _ if resolution:
+            return "chartreuse3"
+        case _:
+            return "bright_white"

--- a/glu/utils.py
+++ b/glu/utils.py
@@ -165,7 +165,9 @@ def capitalize_first_word(text: str) -> str:
     return " ".join([splitted[0].capitalize()] + splitted[1:])
 
 
-def print_panel(title: str | Text, content: str | ConsoleRenderable | RichCast) -> None:
+def print_panel(
+    title: str | Text, content: str | ConsoleRenderable | RichCast, border_style: str = "grey70"
+) -> None:
     console = Console()
     console.print(
         Panel(
@@ -173,7 +175,7 @@ def print_panel(title: str | Text, content: str | ConsoleRenderable | RichCast) 
             title=title,
             title_align="left",
             expand=False,
-            border_style="grey70",
+            border_style=border_style,
         )
     )
 

--- a/tests/clients/jira.py
+++ b/tests/clients/jira.py
@@ -12,6 +12,30 @@ from tests import TESTS_DATA_DIR
 from tests.utils import load_json
 
 
+class JiraObject(BaseModel):
+    name: str
+
+
+class FakeJiraUser(BaseModel):
+    displayName: str
+
+
+class FakeIssueFields(BaseModel):
+    summary: str
+    status: JiraObject
+    priority: JiraObject
+    assignee: FakeJiraUser | None
+    reporter: FakeJiraUser
+    issuetype: JiraObject
+    resolution: JiraObject | None = None
+    description: str | None = None
+
+
+class FakeIssue(BaseModel):
+    key: str
+    fields: FakeIssueFields
+
+
 class FakeJiraClient:
     def myself(self) -> JiraUser:
         return JiraUser("2662", "peter")
@@ -65,23 +89,9 @@ class FakeJiraClient:
         return FakeTicket(new_ticket)  # type: ignore
 
     def search_issues(self, query: str) -> list[Issue]:
-        class JiraObject(BaseModel):
-            name: str
-
-        class JiraUser(BaseModel):
-            displayName: str
-
-        class FakeIssueFields(BaseModel):
-            summary: str
-            status: JiraObject
-            priority: JiraObject
-            assignee: JiraUser | None
-            reporter: JiraUser
-            resolution: JiraObject | None = None
-
-        class FakeIssue(BaseModel):
-            key: str
-            fields: FakeIssueFields
-
         ticket_data = load_json(TESTS_DATA_DIR / "ticket_list.json")
-        return TypeAdapter(list[FakeIssue]).validate_python(ticket_data)
+        return TypeAdapter(list[FakeIssue]).validate_python(ticket_data)  # type: ignore
+
+    def get_issue(self, jira_project: str, ticket_num: int) -> Issue:
+        ticket_data = load_json(TESTS_DATA_DIR / "ticket_detail.json")
+        return FakeIssue.model_validate(ticket_data)  # type: ignore

--- a/tests/data/ticket_detail.json
+++ b/tests/data/ticket_detail.json
@@ -1,0 +1,22 @@
+{
+  "key": "TEST-452",
+  "fields": {
+    "summary": "Add list tickets command",
+    "status": {
+      "name": "To Do"
+    },
+    "priority": {
+      "name": "Medium"
+    },
+    "issuetype": {
+      "name": "Story"
+    },
+    "assignee": {
+      "displayName": "Jack Daly"
+    },
+    "reporter": {
+      "displayName": "Jack Daly"
+    },
+    "description": null
+  }
+}

--- a/tests/data/ticket_list.json
+++ b/tests/data/ticket_list.json
@@ -9,6 +9,9 @@
       "priority": {
         "name": "Medium"
       },
+      "issuetype": {
+        "name": "Story"
+      },
       "assignee": {
         "displayName": "Jack Daly"
       },
@@ -26,6 +29,9 @@
       },
       "priority": {
         "name": "Medium"
+      },
+      "issuetype": {
+        "name": "Bug"
       },
       "assignee": {
         "displayName": "Jack Daly"
@@ -45,6 +51,9 @@
       "priority": {
         "name": "Low"
       },
+      "issuetype": {
+        "name": "Story"
+      },
       "assignee": {
         "displayName": "Peter Sacker"
       },
@@ -62,6 +71,9 @@
       },
       "priority": {
         "name": "High"
+      },
+      "issuetype": {
+        "name": "Story"
       },
       "assignee": {
         "displayName": "Peter Sacker"

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -38,7 +38,7 @@ def test_list_tickets(write_config_w_repo_config, env_cli):
     assert "Medium" in ticket_table
     assert "Low" in ticket_table
     assert "To Do" in ticket_table
-    assert "For revi" in ticket_table
+    assert "For rev" in ticket_table
 
 
 def test_view_ticket(write_config_w_repo_config, env_cli):

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -41,6 +41,22 @@ def test_list_tickets(write_config_w_repo_config, env_cli):
     assert "For revi" in ticket_table
 
 
+def test_view_ticket(write_config_w_repo_config, env_cli):
+    child = pexpect.spawn("glu ticket view 354", env=env_cli, encoding="utf-8")
+
+    child.expect("────╯")
+    ticket_detail = get_terminal_text(child.before + child.after)
+
+    assert "Title:" in ticket_detail
+    assert "Add list tickets command" in ticket_detail
+    assert "Status: To Do" in ticket_detail
+    assert "Type: Story" in ticket_detail
+    assert "Assignee: Jack Daly" in ticket_detail
+    assert "Reporter: Jack Daly" in ticket_detail
+    assert "Priority: Medium" in ticket_detail
+    assert "Body:" not in ticket_detail
+
+
 def _create_ticket(child: spawn, with_ai: bool = False, select_project: bool = False):
     if select_project:
         child.expect("Select project: ")


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-47]
- **Summary**:  
  Adds issue-type filtering to `glu ticket list`, displays a Type column, implements a new `glu ticket view` command to show full ticket details, refactors panel styling and color logic, and fixes a typo in PR merge manual edit.

- **Implementation details**:  
  • In `glu ticket list`:  
    – New `--type`/`-t` option to add `issuetype IN (…)` to JQL filters  
    – Type column added to the Rich table  
    – Color‐assignment logic extracted into `get_color_for_priority` and `get_color_for_status` helpers  
  • New `glu ticket view` command in `glu/cli/ticket/view.py`:  
    – Fetches ticket via `JiraClient.get_issue`  
    – Renders title, optional body, status, type, assignee, reporter, and priority in a styled panel  
  • Refactor in `glu/utils.py`: `print_panel` now accepts a `border_style` parameter to match status colors  
  • Fix in `glu/cli/pr/merge.py`: manual edit step now uses `proposed_commit_message` instead of `summary_commit_message`  
  • Tests updated/added:  
    – JSON fixtures now include `issuetype` for list and detail  
    – FakeJiraClient implements `get_issue`  
    – `test_view_ticket` verifies the new view output  

### Changes

- glu/cli/ticket/index.py  
  • Register new `view` subcommand  
  • Add `types` option to `list` signature  
- glu/cli/ticket/list.py  
  • Apply `types` filter to JQL  
  • Add Type column to output table  
  • Replace inline color logic with helper calls  
- glu/cli/ticket/view.py  
  • New file implementing detailed ticket panel renderer  
- glu/jira.py  
  • New `JiraClient.get_issue` method  
  • New color helper functions for priority and status  
- glu/utils.py  
  • Extend `print_panel` to accept custom `border_style`  
- glu/cli/pr/merge.py  
  • Fix manual edit commit message variable  
- tests/  
  • Add `tests/data/ticket_detail.json`  
  • Update `ticket_list.json` to include issuetype  
  • Extend FakeJiraClient with `get_issue` and new pydantic models  
  • Add `test_view_ticket`  

### Test Plan

1. Existing and new tests cover list filtering, color rendering, and the new `glu ticket view` output.  
2. No special environment changes required.

### Dependencies

None new beyond existing Jira and Rich clients.

### Future Enhancements / Open questions / Risks / Technical Debt

- Potential extension: allow customizing which fields appear in `view`.  
- Large description bodies could overflow; consider paging or truncation.

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.  
- [ ] Tests have been added or modified for all new features and bug fixes.  
- [ ] All FIXMEs have been addressed.  
- [ ] Code changes or additions do not introduce significant performance issues.  
- [ ] If necessary, documentation has been updated.  
- [ ] I have sufficiently commented my code, either within this PR or the code itself, to guide reviewers and future coders through my changes and the intended results.  
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.  
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken to not require backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-47]: https://brightnight.atlassian.net/browse/GLU-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ