### PR TITLE
feat: Display mergeability status

### DIFF
--- a/glu/cli/pr/index.py
+++ b/glu/cli/pr/index.py
@@ -150,7 +150,10 @@ def view(
     show_checks: Annotated[
         bool,
         typer.Option(
-            "--checks", "-m", help="Show CI checks (not enabled by default for performance reasons)"
+            "--checks",
+            "--show-checks",
+            "-c",
+            help="Show CI checks (not enabled by default for performance reasons)",
         ),
     ] = False,
 ):

--- a/glu/cli/pr/view.py
+++ b/glu/cli/pr/view.py
@@ -64,6 +64,13 @@ def view_pr(  # noqa: C901
         text_with_emojis = replace_emoji(f" {':speech_balloon:'} {pr.comments}")
         renderables.append(Text(text_with_emojis))
 
+    if not pr.mergeable:
+        renderables.append(
+            Text("Mergeability: ", style="grey70").append(
+                pr.mergeable_state, style="bright_white on red"
+            )
+        )
+
     if show_checks:
         relevant_checks = []
         pr_checks = gh.get_pr_checks(pr_num)


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-50]
- **Summary**:  
  This PR renames the CI checks flag in the `glpr view` command for clarity and surfaces a mergeability indicator when a PR cannot be merged.
- **Implementation details**:  
  - In `glu/cli/pr/index.py`, changed the checks option from `-m` to `-c` and added a new long-form flag `--show-checks`.  
  - In `glu/cli/pr/view.py`, added logic to detect non-mergeable PRs and append a styled “Mergeability: <state>” label (bright white text on red background).

### Changes

- **glu/cli/pr/index.py**  
  - Renamed the CI checks option shortcuts: replaced `-m` with `-c`.  
  - Introduced `--show-checks` as a clearer long-form flag alongside `--checks`.

- **glu/cli/pr/view.py**  
  - Checked `pr.mergeable` status.  
  - Appended a red-highlighted “Mergeability: <state>” label for PRs that are not mergeable.

### Test Plan

1. Run `glpr view --help` to confirm the option flags update (`-c`, `--show-checks`).  
2. View a mergeable PR: verify no mergeability label is shown.  
3. View a non-mergeable PR: verify the “Mergeability: <state>” label appears and is styled correctly.  

### Dependencies

- None

### Future Enhancements / Open questions / Risks / Technical Debt

- Consider adding automated tests for the styled mergeability label in the CLI renderer.  

### Checklist

- [ ] Code has been linted and adheres to style guidelines.  
- [ ] Relevant tests have been added or updated.  
- [ ] All FIXMEs have been addressed.  
- [ ] No new performance regressions introduced.  
- [ ] Documentation (help text) has been updated to reflect flag changes.  
- [ ] Breaking changes: CLI flags updated; ensure no scripts rely on the old `-m` flag.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-50]: https://brightnight.atlassian.net/browse/GLU-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ