### PR TITLE
feat: Cli(ticket): add search, assignee and reporter filters to list command

### DIFF
--- a/glu/cli/ticket/index.py
+++ b/glu/cli/ticket/index.py
@@ -77,6 +77,10 @@ def create(
 @app.command(name="list", short_help="List Jira tickets")
 def list_tickets(
     project: Annotated[str | None, typer.Option("--project", "-p", help="Jira project")] = None,
+    search: Annotated[
+        str | None,
+        typer.Option("--search", "-q", help="Filter by text", show_default=False),
+    ] = None,
     only_mine: Annotated[
         bool,
         typer.Option("--only-mine", "-m", help="Only show my tickets"),
@@ -124,6 +128,24 @@ def list_tickets(
             show_default=False,
         ),
     ] = None,
+    assignee: Annotated[
+        str | None,
+        typer.Option(
+            "--assignee",
+            "-a",
+            help="Filter by assignee",
+            show_default=False,
+        ),
+    ] = None,
+    reporter: Annotated[
+        str | None,
+        typer.Option(
+            "--reporter",
+            "-r",
+            help="Filter by reporter",
+            show_default=False,
+        ),
+    ] = None,
     in_progress_only: Annotated[
         bool,
         typer.Option(
@@ -135,11 +157,14 @@ def list_tickets(
 ):
     list_tickets_core(
         project,
+        search,
         only_mine,
         statuses,
         order_by_priority,
         priorities,
         types,
+        assignee,
+        reporter,
         in_progress_only,
         open=not show_closed,
     )

--- a/glu/cli/ticket/list.py
+++ b/glu/cli/ticket/list.py
@@ -12,11 +12,14 @@ from glu.utils import abbreviate_last_name, print_error, print_panel, suppress_t
 @suppress_traceback
 def list_tickets(  # noqa: C901
     project: str | None,
+    search: str | None,
     only_mine: bool,
     statuses: list[str] | None,
     order_by_priority: bool,
     priorities: list[str] | None,
     types: list[str] | None,
+    assignee: str | None,
+    reporter: str | None,
     in_progress_only: bool,
     open: bool,
 ) -> None:
@@ -36,6 +39,11 @@ def list_tickets(  # noqa: C901
     issue_filters = [f"project={jira_project}"]
     if only_mine:
         issue_filters.append("assignee = currentUser()")
+    elif assignee:
+        issue_filters.append(f'assignee="{assignee}"')
+
+    if reporter:
+        issue_filters.append(f'reporter="{reporter}"')
 
     if statuses:
         issue_filters.append(f"status IN ({','.join(statuses)})")
@@ -51,6 +59,9 @@ def list_tickets(  # noqa: C901
     if priorities:
         issue_filters.append(f"priority IN ({','.join(priorities)})")
 
+    if search:
+        issue_filters.append(f'text ~ "{search}"')
+
     order = "priority" if order_by_priority else "created"
     issue_filter = f"{' and '.join(issue_filters)} order by {order} desc"
 
@@ -58,6 +69,7 @@ def list_tickets(  # noqa: C901
 
     if not issues:
         rich.print("No issues found")
+        return
 
     ticket_table = Table(
         Column(width=2),


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-52]
- **Summary**: Add new filtering options (--search/-q, --assignee/-a, --reporter/-r) to the `glu ticket list` CLI command to allow users to filter issues by text, assignee, or reporter.
- **Implementation details**: Introduced new Typer options in `glu/cli/ticket/index.py`, passed them into the core listing function, and enhanced `issue_filters` in `glu/cli/ticket/list.py` to append JQL clauses for text, assignee, and reporter. Also return early when no issues match the filters.

### Changes

- glu/cli/ticket/index.py: added `search`, `assignee`, and `reporter` options and forwarded them to `list_tickets_core`.
- glu/cli/ticket/list.py: updated `issue_filters` to include `text ~`, `assignee=`, and `reporter=` criteria; return immediately if no issues found after filtering.

### Test Plan

1. Run `glu ticket list --search "bug"` and verify only issues containing "bug" in text are shown.
2. Run with `--assignee john.doe` and/or `--reporter jane.smith` to ensure correct filtering.
3. Confirm combination of filters works and output returns early with "No issues found" when appropriate.

### Dependencies

None

### Future Enhancements / Open questions / Risks / Technical Debt

- Consider adding partial or regex matching support for filters.

### Checklist

- [ ] Code has been linted and adheres to style guidelines.
- [ ] Tests have been added or modified for all new filters.
- [ ] All FIXMEs have been addressed.
- [ ] No significant performance regressions introduced.
- [ ] Documentation updated if necessary.
- [ ] Code sufficiently commented for future maintainers.
- [ ] Reviewers have been selected appropriately.
- [ ] Breaking changes vetted for backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)