### PR TITLE
Added logic to set the upstream branch if unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- version list -->
 
+## v2.7.0 (2025-08-13)
+
+### Features
+
+- pr(create): set upstream for non-base local branches when creating a PR to ensure smooth subsequent pushes/pulls.
+
 ## v2.6.0 (2025-07-27)
 
 ### Chores

--- a/glu/__init__.py
+++ b/glu/__init__.py
@@ -2,4 +2,4 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent.parent
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"

--- a/glu/cli/pr/create.py
+++ b/glu/cli/pr/create.py
@@ -68,7 +68,7 @@ def create_pr(  # noqa: C901
 
                 checkout_to_branch(git, chat_client, gh.default_branch, commit_data.message)
                 latest_commit = git.create_commit(commit_data.message)
-                git.push()
+                git.push(set_upstream_if_unset=(git.current_branch != gh.default_branch))
             case "Commit and push with manual message":
                 git.create_commit("chore: [dry run commit]", dry_run=True)
                 commit_message = typer.edit("")
@@ -78,7 +78,7 @@ def create_pr(  # noqa: C901
 
                 checkout_to_branch(git, chat_client, gh.default_branch, commit_message)
                 latest_commit = git.create_commit(commit_message)
-                git.push()
+                git.push(set_upstream_if_unset=(git.current_branch != gh.default_branch))
             case "Proceed anyway":
                 checkout_to_branch(git, chat_client, gh.default_branch, commit_message=None)
             case _:
@@ -86,14 +86,14 @@ def create_pr(  # noqa: C901
                 raise typer.Exit(1)
 
     if not git.confirm_branch_exists_in_remote():
-        git.push()
+        git.push(set_upstream_if_unset=(git.current_branch != gh.default_branch))
 
     if not git.remote_branch_in_sync():
         confirm_push = typer.confirm(
             "Local branch is not up to date with remote. Push to remote now?"
         )
         if confirm_push:
-            git.push()
+            git.push(set_upstream_if_unset=(git.current_branch != gh.default_branch))
 
     jira = get_jira_client()
 

--- a/glu/local.py
+++ b/glu/local.py
@@ -108,9 +108,14 @@ class GitClient:
             rich.print(err)
             raise typer.Exit(1) from err
 
-    def push(self) -> None:
+    def push(self, set_upstream_if_unset: bool = False) -> None:
         try:
-            self._repo.git.push("origin", self._repo.active_branch.name)
+            branch_name = self._repo.active_branch.name
+            tracking = self._repo.active_branch.tracking_branch()
+            if set_upstream_if_unset and tracking is None:
+                self._repo.git.push("--set-upstream", "origin", branch_name)
+            else:
+                self._repo.git.push("origin", branch_name)
         except GitCommandError as err:
             rich.print(err)
             raise typer.Exit(1) from err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glu-cli"
-version = "2.6.0"
+version = "2.7.0"
 description = "A CLI tool to facilitate the developer workflow"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/clients/git.py
+++ b/tests/clients/git.py
@@ -63,7 +63,7 @@ class FakeGitClient:
             "- Add testing through pexpect and pytest\n- Added very many good tests",
         )
 
-    def push(self) -> None:
+    def push(self, set_upstream_if_unset: bool = False) -> None:
         os.environ["IS_REMOTE_BRANCH_IN_SYNC"] = "1"
         pass
 


### PR DESCRIPTION
### Description

- **Jira Ticket**: [XY-1234]
- **Summary**: Adds logic to automatically set the upstream branch when pushing non-default branches during PR creation, and bumps the project version to 2.7.0.
- **Implementation details**: 
  • Extended GitClient.push to accept a `set_upstream_if_unset` flag and use `--set-upstream` if the local branch has no tracking branch.
  • Updated all `git.push()` calls in `glu/cli/pr/create.py` to pass this flag when the current branch is not the default branch.
  • Bumped version in `CHANGELOG.md`, `glu/__init__.py`, and `pyproject.toml` to 2.7.0.

### Changes

- CHANGELOG.md: Added v2.7.0 entry describing the new upstream behavior.
- glu/__init__.py & pyproject.toml: Updated package version to 2.7.0.
- glu/cli/pr/create.py: Modified `git.push()` invocations to `git.push(set_upstream_if_unset=(git.current_branch != gh.default_branch))`.
- glu/local.py: Extended `GitClient.push()` signature and logic to set upstream if no remote tracking branch.
- tests/clients/git.py: Updated FakeGitClient.push signature to accept the new flag.

### Test Plan

<!--
1. Ensure existing unit tests for PR creation and git push behavior still pass.
2. Verify that pushing a new branch sets the upstream correctly and subsequent pushes work without `--set-upstream`.
-->

### Dependencies

<!--
* No new external dependencies introduced.
-->

### Future Enhancements / Open questions / Risks / Technical Debt

<!--
* Consider handling cases where the remote branch already exists under a different upstream.
-->

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)