### PR TITLE
fix: Prioritize approved status over change requests in get_pr_approval_status

### DIFF
--- a/glu/gh.py
+++ b/glu/gh.py
@@ -198,11 +198,11 @@ def get_pr_approval_status(
 ) -> Literal["approved", "changes_requested"] | None:
     reviews = get_all_from_paginated_list(paginated_reviews)
 
-    if any(review.state == "CHANGES_REQUESTED" for review in reviews):
-        return "changes_requested"
-
     if any(review.state == "APPROVED" for review in reviews):
         return "approved"
+
+    if any(review.state == "CHANGES_REQUESTED" for review in reviews):
+        return "changes_requested"
 
     return None
 


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-56]
- **Summary**: Adjusts the approval status logic in `get_pr_approval_status` so that an approved review takes precedence over any existing change requests.
- **Implementation details**: Moved the `CHANGES_REQUESTED` check to after the `APPROVED` check, simplifying the decision flow and ensuring that an approval is reported even when there are outstanding change requests.

### Changes

- Modified `glu/gh.py` in the `get_pr_approval_status` function:
  - Removed the initial `CHANGES_REQUESTED` guard and placed it below the `APPROVED` check.
  - Preserved the `None` return when no relevant review state is found.

### Test Plan

<!--
1. Verify that when both approved and change requested reviews exist, the function returns "approved".
2. Confirm that when only change requests exist, it returns "changes_requested".
3. Check that it returns `None` if neither state is present.
-->

### Dependencies

<!-- None -->

### Future Enhancements / Open questions / Risks / Technical Debt

<!--
- Consider adding unit tests for mixed review states to prevent regressions.
-->

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-56]: https://brightnight.atlassian.net/browse/GLU-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ