### PR TITLE
fix: Fix commit generation parsing when type is contained inside title

### DIFF
--- a/glu/models.py
+++ b/glu/models.py
@@ -60,8 +60,8 @@ class CommitGeneration(BaseModel):
         if self.title.count(":") > 1:
             raise ValueError("The char ':' should never appear more than once in the title.")
 
-        if self.type in self.title:
-            self.title = self.title.split(":")[1].strip()
+        if f"{self.type}:" in self.title:
+            self.title = self.title.replace(f"{self.type}:", "").strip()
 
         self.title = capitalize_first_word(self.title)
         return self


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-57]
- **Summary**: Fix commit title parsing to remove leading type prefix correctly
- **Implementation details**: Update CommitGeneration to detect type prefixes (e.g. 'feat:') and strip them using `replace` instead of splitting on `:`

### Changes

<!-- List all major pages and components affected and briefly describe the nature of the change in each. -->
- glu/models.py: Adjust CommitGeneration parsing logic to remove the `{type}:` prefix when present

### Test Plan

<!--
1. Describe the testing coverage and any notable missing coverage.
2. Any special setup required (new environment variables, dependencies, etc.).
-->
- Verified titles with and without a type prefix parse correctly under existing tests

### Dependencies

<!--
* List any new dependencies introduced.
* Mention if any dependencies have been removed or updated.
-->
- None

### Future Enhancements / Open questions / Risks / Technical Debt

<!--
List out any follow up work suggested/discussed during PR review/planning.
-->
- None

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.


Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-57]: https://brightnight.atlassian.net/browse/GLU-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ