### PR TITLE
fix(commit-gen): Fix double entry of type prefix in commit title when generating with AI

### DIFF
--- a/glu/models.py
+++ b/glu/models.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -60,8 +61,11 @@ class CommitGeneration(BaseModel):
         if self.title.count(":") > 1:
             raise ValueError("The char ':' should never appear more than once in the title.")
 
-        if f"{self.type}:" in self.title:
-            self.title = self.title.replace(f"{self.type}:", "").strip()
+        type_prefix_pattern = r"^([a-zA-Z0-9_-]+(?:\([^)]+\))?):\s+(.+)"
+        if match := re.match(type_prefix_pattern, self.title):
+            type_prefix = match.group(1)
+            self.title = self.title.replace(f"{type_prefix}:", "").strip()
+            self.type = type_prefix
 
         self.title = capitalize_first_word(self.title)
         return self

--- a/tests/clients/ai.py
+++ b/tests/clients/ai.py
@@ -21,7 +21,10 @@ class FakeChatClient:
         if "adding testing" in msg:
             return json.dumps(load_json("ai_ticket.json"))
         if "Provide a commit message for the following diff" in msg:
-            return json.dumps(load_json("commit_message.json"))
+            cmt_msg = load_json("commit_message.json")
+            if os.getenv("IS_COMMIT_MSG_TITLE_SCOPED"):
+                cmt_msg["title"] = f"refactor(service):{cmt_msg['title'].replace('refactor:', '')}"
+            return json.dumps(cmt_msg)
         if "Provide the issue type for a Jira ticket" in msg:
             return "Chore"
         if "Provide a description and summary for a Jira" in msg:


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-59]
- **Summary**: Fix double-entry of type prefix in AI-generated commit titles.
- **Implementation details**: Use regex in `CommitGeneration` to detect and strip existing `type` or `type(scope)` prefixes from the title, and update `self.type` from the matched group.

### Changes

- glu/models.py: Added regex-based prefix stripping in `CommitGeneration` to avoid duplicate prefixes.
- tests/clients/ai.py: Extended FakeChatClient to simulate scoped commit titles via `IS_COMMIT_MSG_TITLE_SCOPED`.
- tests/test_prs.py: Introduced `test_create_pr_w_commit_generation` to verify scoped prefix handling and title formatting.

### Test Plan

- Run all unit tests, including the new `test_create_pr_w_commit_generation`, to confirm correct prefix removal and capitalization.

### Dependencies


### Future Enhancements / Open questions / Risks / Technical Debt


### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-59]: https://brightnight.atlassian.net/browse/GLU-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ