### PR TITLE
fix: Switch default OpenAI model to gpt-5-mini to fix empty responses with o4-mini

### DIFF
--- a/glu/config.py
+++ b/glu/config.py
@@ -235,6 +235,9 @@ MODEL_TOKEN_LIMITS = {
     "gpt-4.1": 1_047_576,
     "gpt-4.1-nano": 1_047_576,
     "gpt-4.1-mini": 1_047_576,
+    "gpt-5": 400_000,
+    "gpt-5-mini": 400_000,
+    "gpt-5-nano": 400_000,
     # === Anthropic (Claude) === https://docs.anthropic.com/en/docs/about-claude/models/overview
     "claude-1": 100000,
     "claude-2": 100000,
@@ -248,6 +251,7 @@ MODEL_TOKEN_LIMITS = {
     "claude-3-7-sonnet-20250219": 200_000,
     "claude-3-5-sonnet-20241022": 200_000,
     "claude-3-5-haiku-20241022": 200_000,
+    "claude-sonnet-4-5": 200_000,
     # === Google (Gemini) === https://ai.google.dev/gemini-api/docs/models
     "gemini-pro": 32000,
     "gemini-pro-vision": 32000,
@@ -270,4 +274,8 @@ MODEL_TOKEN_LIMITS = {
     "grok-3-fast": 131072,
     "grok-3-mini": 131072,
     "grok-3-mini-fast": 131072,
+    "grok-4-0709": 256_000,
+    "grok-code-fast-1": 256_000,
+    "grok-4-fast-reasoning": 2_000_000,
+    "grok-4-fast-non-reasoning": 2_000_000,
 }

--- a/glu/config.py
+++ b/glu/config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 from glu.models import ChatProvider
 
 DEFAULT_MODELS: dict[ChatProvider, str] = {
-    "OpenAI": "o4-mini",
+    "OpenAI": "gpt-5-mini",
     "Gemini": "gemini-2.0-flash",
     "Anthropic": "claude-sonnet-4-0",
     "xAI": "grok-3-mini-fast",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -109,7 +109,7 @@ def test_init(env_cli):
             "github_pat": "dfj2k39f04",
             "openai_config": {
                 "api_key": "adf23hggj9400h",
-                "model": "o4-mini",
+                "model": "gpt-5-mini",
                 "provider": "OpenAI",
             },
         },


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-60]
- **Summary**: Switch the default OpenAI model to gpt-5-mini and unify/Improve JSON/validation error handling across AI generation functions to address empty or malformed AI responses and reduce duplicated code.
- **Implementation details**: Added a helper _format_error to centralize JSONDecodeError/ValidationError message construction. Replaced repeated error-handling blocks in generate_description, generate_ticket, generate_commit_message, and generate_final_commit_message with calls to _format_error. Improved empty-response reporting and include error context in print_error when final commit generation fails. Increased token buffer for trimming PR diffs passed to final commit message generation. Updated default OpenAI model from "o4-mini" to "gpt-5-mini" in config.

### Changes

<!-- List all major pages and components affected and briefly describe the nature of the change in each. -->

- glu/ai.py
  - Added _format_error(err, response_format, response) to standardize error messages for JSONDecodeError and ValidationError.
  - Replaced duplicated error construction in generate_description, generate_ticket, generate_commit_message, and generate_final_commit_message with calls to _format_error.
  - Improved error output when AI returns an empty response and included error context in the final commit generation failure print.
  - Increased buffer_tokens passed to _trim_text_to_fit_token_limit for final commit message generation to reduce truncated diffs causing bad outputs.
- glu/config.py
  - DEFAULT_MODELS: changed OpenAI default from "o4-mini" to "gpt-5-mini".

### Test Plan

<!--
1. Describe the testing coverage and any notable missing coverage.
2. Any special setup required (new environment variables, dependencies, etc.).
-->

1. Manually run generation flows that produce description, ticket, commit message, and final commit message to verify:
   - Proper handling and readable error messages when the AI returns malformed JSON.
   - Clear message when the AI response is empty; try forcing an empty response or use a model known to produce empty outputs.
   - No regressions in normal successful runs when valid JSON is returned.
2. Confirm default model used is gpt-5-mini (no env changes required unless overriding defaults).

### Dependencies

<!--
* List any new dependencies introduced.
* Mention if any dependencies have been removed or updated.
-->

- No new external dependencies introduced. Only internal refactors and config change for default model.

### Future Enhancements / Open questions / Risks / Technical Debt

<!--
List out any follow up work suggested/discussed during PR review/planning.
These would help keep record of things discussed but not implemented.
For e.g. refactor may be required as this PR adds technical debt.
-->

- Consider centralizing other cross-cutting AI error handling and logging in a shared utility module if more handlers are added.
- Review the token buffer value (2500) for different models and repo sizes; might need tuning per-model or per-repo heuristics.
- Monitor for any model-specific behaviors with gpt-5-mini and fall back strategies if empty responses persist.

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.
<!-- Add as needed -->

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-60]: https://brightnight.atlassian.net/browse/GLU-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ