### PR TITLE
feat(pr): add --skip-generation flag to `glu pr update` and make generation optional

### DIFF
--- a/glu/cli/pr/index.py
+++ b/glu/cli/pr/index.py
@@ -213,6 +213,14 @@ def update(
             help="Skip description generation",
         ),
     ] = False,
+    skip_title_update: Annotated[
+        bool,
+        typer.Option(
+            "--skip-title-update",
+            "-st",
+            help="Skip title update",
+        ),
+    ] = False,
 ):
     update_pr(
         pr_num,
@@ -224,4 +232,5 @@ def update(
         model,
         ready_for_review,
         skip_generation,
+        skip_title_update,
     )

--- a/glu/cli/pr/index.py
+++ b/glu/cli/pr/index.py
@@ -205,5 +205,23 @@ def update(
             help="Move ticket to ready for review",
         ),
     ] = False,
+    skip_generation: Annotated[
+        bool,
+        typer.Option(
+            "--skip-generation",
+            "-s",
+            help="Skip description generation",
+        ),
+    ] = False,
 ):
-    update_pr(pr_num, ticket, project, draft, reviewers, provider, model, ready_for_review)
+    update_pr(
+        pr_num,
+        ticket,
+        project,
+        draft,
+        reviewers,
+        provider,
+        model,
+        ready_for_review,
+        skip_generation,
+    )

--- a/glu/cli/pr/update.py
+++ b/glu/cli/pr/update.py
@@ -18,11 +18,12 @@ from glu.jira import (
     search_and_prompt_for_jira_ticket,
 )
 from glu.local import get_git_client
+from glu.models import PRDescriptionGeneration
 from glu.utils import add_generated_with_glu_tag, print_error, suppress_traceback
 
 
 @suppress_traceback
-def update_pr(
+def update_pr(  # noqa: C901
     number: int,
     ticket: str | None,
     project: str | None,
@@ -31,16 +32,13 @@ def update_pr(
     provider: str | None,
     model: str | None,
     ready_for_review: bool,
+    skip_generation: bool,
 ) -> None:
     try:
         git = get_git_client()
     except InvalidGitRepositoryError as err:
         print_error("Not valid a git repository")
         raise typer.Exit(1) from err
-
-    chat_client = get_ai_client(model)
-    chat_provider = prompt_for_chat_provider(chat_client, provider)
-    chat_client.set_chat_model(chat_provider)
 
     gh = get_github_client(git.repo_name)
 
@@ -54,35 +52,46 @@ def update_pr(
         gh, reviewers, git.repo_name, draft or bool(pr.requested_reviewers)
     )
 
-    pr_template = gh.get_contents(".github/pull_request_template.md")
-    pr_diff = gh.get_pr_diff(number)
-    rich.print("[grey70]Generating description...[/]")
-    pr_gen = generate_description(
-        chat_client, pr_template, git.repo_name, pr_diff, pr.body, generate_title=True
-    )
+    pr_gen: PRDescriptionGeneration | None = None
+    generated_pr_description: str | None = None
+    if not skip_generation:
+        chat_client = get_ai_client(model)
+        chat_provider = prompt_for_chat_provider(chat_client, provider)
+        chat_client.set_chat_model(chat_provider)
 
-    formatted_ticket = search_and_prompt_for_jira_ticket(jira_project, ticket, text=pr.body)
+        rich.print("[grey70]Generating description...[/]")
 
-    pr_description = pr_gen.description
-    if formatted_ticket:
-        pr_description = add_jira_key_to_pr_description(pr_description, formatted_ticket)
-    if PREFERENCES.add_generated_with_glu_tag:
-        pr_description = add_generated_with_glu_tag(pr_description)
+        pr_template = gh.get_contents(".github/pull_request_template.md")
+        pr_diff = gh.get_pr_diff(number)
+
+        pr_gen = generate_description(
+            chat_client, pr_template, git.repo_name, pr_diff, pr.body, generate_title=True
+        )
+
+        formatted_ticket = search_and_prompt_for_jira_ticket(jira_project, ticket, text=pr.body)
+
+        pr_description = pr_gen.description
+        if formatted_ticket:
+            pr_description = add_jira_key_to_pr_description(pr_description, formatted_ticket)
+        if PREFERENCES.add_generated_with_glu_tag:
+            pr_description = add_generated_with_glu_tag(pr_description)
+        generated_pr_description = pr_description
 
     gh.update_pr(
         pr,
-        pr_gen.title,
-        body=pr_description,
+        pr_gen.title if pr_gen else None,
+        body=generated_pr_description,
         draft=draft,
     )
 
     if selected_reviewers:
         gh.add_reviewers_to_pr(pr, selected_reviewers)
 
-    rich.print(f"\n[grey70]{pr_description}[/]\n")
+    if generated_pr_description:
+        rich.print(f"\n[grey70]{generated_pr_description}[/]\n")
     rich.print(
         f":page_facing_up: Updated PR in [blue]{git.repo_name}[/] "
-        f"with title [bold green]'{pr_gen.title}'[/]"
+        f"with title [bold green]'{pr_gen.title if pr_gen else pr.title}'[/]"
     )
     rich.print(f"[dark violet]https://github.com/{git.repo_name}/pull/{number}[/]")
 

--- a/glu/cli/pr/update.py
+++ b/glu/cli/pr/update.py
@@ -33,6 +33,7 @@ def update_pr(  # noqa: C901
     model: str | None,
     ready_for_review: bool,
     skip_generation: bool,
+    skip_title_update: bool,
 ) -> None:
     try:
         git = get_git_client()
@@ -65,7 +66,12 @@ def update_pr(  # noqa: C901
         pr_diff = gh.get_pr_diff(number)
 
         pr_gen = generate_description(
-            chat_client, pr_template, git.repo_name, pr_diff, pr.body, generate_title=True
+            chat_client,
+            pr_template,
+            git.repo_name,
+            pr_diff,
+            pr.body,
+            generate_title=not skip_title_update,
         )
 
         formatted_ticket = search_and_prompt_for_jira_ticket(jira_project, ticket, text=pr.body)
@@ -91,7 +97,7 @@ def update_pr(  # noqa: C901
         rich.print(f"\n[grey70]{generated_pr_description}[/]\n")
     rich.print(
         f":page_facing_up: Updated PR in [blue]{git.repo_name}[/] "
-        f"with title [bold green]'{pr_gen.title if pr_gen else pr.title}'[/]"
+        f"with title [bold green]'{pr_gen.title if pr_gen and pr_gen.title else pr.title}'[/]"
     )
     rich.print(f"[dark violet]https://github.com/{git.repo_name}/pull/{number}[/]")
 

--- a/glu/gh.py
+++ b/glu/gh.py
@@ -65,10 +65,12 @@ class GithubClient:
         pr: PullRequest,
         title: str | None,
         body: str | None,
-        draft: bool | None,
+        draft: bool,
     ) -> None:
         if draft and not pr.draft:
             pr.convert_to_draft()
+        elif not draft and pr.draft:
+            pr.mark_ready_for_review()
 
         pr.edit(title or NotSet, body or NotSet)
 

--- a/tests/test_prs.py
+++ b/tests/test_prs.py
@@ -169,6 +169,20 @@ def test_update_pr(env_cli, write_config_w_repo_config):
     assert "https://github.com/github/Test-Repo/pull/" in lines[-1]
 
 
+def test_update_pr_no_generation(env_cli, write_config_w_repo_config):
+    child = pexpect.spawn("glu pr update 353 -s", env=env_cli, encoding="utf-8")
+
+    child.expect(re.compile(r"https://github\.com/github/Test-Repo/pull/\d+"))
+    text = get_terminal_text(child.before + child.after).strip()
+    lines = text.splitlines()
+
+    assert (
+        " ".join(lines[:2]) == "📄 Updated PR in github/Test-Repo with title "
+        "'fix: fix ticket not being properly added to pr descriptions'"
+    )
+    assert "https://github.com/github/Test-Repo/pull/" in lines[-1]
+
+
 def _create_pr(
     child: pexpect.spawn,
     is_git_dirty: bool = False,


### PR DESCRIPTION
### Description

- **Jira Ticket**: [GLU-63]
- **Summary**: Add a --skip-generation (-s) option to `glu pr update` so callers can skip AI-based PR title/description generation. Make generation optional so the AI/chat client is only instantiated when generation is enabled. Treat generated title/description as optional and fall back to the PR's existing title/body when generation is skipped or not available. Make GitHub draft handling explicit by converting to/from draft before editing the PR.
- **Implementation details**: Introduced a CLI flag and propagated it into update_pr. update_pr now only constructs the AI/chat client and calls generate_description when generation is not skipped. PRDescriptionGeneration and the generated description are optional; update_pr uses generated values when present and otherwise falls back to the PR's existing title/body. GithubClient.update_pr signature was changed to require a boolean draft and will explicitly convert a PR to draft or mark it ready for review prior to calling edit.

### Changes

- glu/cli/pr/index.py: Add new --skip-generation / -s option and pass it to update_pr.
- glu/cli/pr/update.py: Make description/title generation optional; only instantiate AI/chat client when not skipping generation; treat generated title/description as optional and fall back to existing PR values; adjust printed output to reflect fallback title/description.
- glu/gh.py: GithubClient.update_pr now requires draft: bool and explicitly converts a PR to draft or marks it ready for review before editing.
- tests/test_prs.py: Add test_update_pr_no_generation to verify behavior when generation is skipped.

### Test Plan

1. Added test_update_pr_no_generation to validate running `glu pr update <num> -s` prints the updated PR URL and retains the existing title when generation is skipped. Existing update PR tests remain in place.
2. No special environment setup beyond existing test fixtures/configuration.

### Dependencies

None.

### Future Enhancements / Open questions / Risks / Technical Debt

- Converting PR draft state relies on API permissions; callers may encounter permission errors in some orgs—consider surfacing clearer errors or adding retries if toggling fails.
- update_pr's change to require draft: bool means any external callers must pass an explicit boolean; ensure all call sites are updated.
- Consider centralizing draft-toggle logic or adding retries/error handling for API rate/permission issues.

### Checklist

- [ ] Code has been linted and adheres the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.

Generated with [glu](https://github.com/BrightNight-Energy/glu)

[GLU-63]: https://brightnight.atlassian.net/browse/GLU-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ