### PR TITLE
fix(jira): Prevent epic tickets from getting created

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,10 +3,10 @@ name: CI/CD
 on:
   push:
     branches:
-      - '**'
+      - "**"
 
 env:
-  PYTHON_VERSION: '3.13'
+  PYTHON_VERSION: "3.13"
 
 concurrency:
   group: ${{ github.event.ref }}
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history so semantic-release can resolve commits
+          fetch-depth: 0 # Fetch all history so semantic-release can resolve commits
           token: ${{ secrets.CICD_RELEASE_GITHUB_TOKEN }}
       - uses: 1password/load-secrets-action/configure@v2
         with:

--- a/glu/cli/pr/create.py
+++ b/glu/cli/pr/create.py
@@ -15,6 +15,7 @@ from glu.config import JIRA_IN_PROGRESS_TRANSITION, JIRA_READY_FOR_REVIEW_TRANSI
 from glu.gh import get_github_client, prompt_for_reviewers
 from glu.jira import (
     add_jira_key_to_pr_description,
+    filter_creatable_issuetypes,
     format_jira_ticket,
     generate_ticket_with_ai,
     get_jira_client,
@@ -126,7 +127,11 @@ def create_pr(  # noqa: C901
             jira_project = jira_project or get_jira_project(jira, git.repo_name, project)
             rich.print("[grey70]Generating ticket...[/]\n")
 
-            issuetypes = jira.get_issuetypes(jira_project)
+            issuetypes = filter_creatable_issuetypes(jira.get_issuetypes(jira_project))
+            if not issuetypes:
+                print_error("No non-Epic Jira issue types are available for ticket creation.")
+                raise typer.Exit(1)
+
             ticket_data = generate_ticket_with_ai(
                 chat_client,
                 git.repo_name,

--- a/glu/cli/ticket/create.py
+++ b/glu/cli/ticket/create.py
@@ -8,13 +8,15 @@ from InquirerPy import inquirer
 from glu.ai import get_ai_client, prompt_for_chat_provider
 from glu.config import DEFAULT_JIRA_PROJECT, PREFERENCES
 from glu.jira import (
+    filter_creatable_issuetypes,
     generate_ticket_with_ai,
     get_jira_client,
     get_jira_project,
     get_user_from_jira,
+    is_forbidden_create_issuetype,
 )
 from glu.local import get_git_client
-from glu.utils import add_generated_with_glu_tag, prompt_or_edit, suppress_traceback
+from glu.utils import add_generated_with_glu_tag, print_error, prompt_or_edit, suppress_traceback
 
 
 @suppress_traceback
@@ -42,14 +44,24 @@ def create_ticket(
     if not project:
         project = get_jira_project(jira, repo_name)
 
-    types = jira.get_issuetypes(project or "")
-    if not issue_type:
+    types = filter_creatable_issuetypes(jira.get_issuetypes(project or ""))
+    if not types:
+        print_error("No non-Epic Jira issue types are available for ticket creation.")
+        raise typer.Exit(1)
+
+    matching_issue_type = next(
+        (
+            available_type
+            for available_type in types
+            if issue_type and available_type.casefold() == issue_type.strip().casefold()
+        ),
+        None,
+    )
+
+    if not matching_issue_type or is_forbidden_create_issuetype(issue_type):
         issuetype = inquirer.select("Select type:", types).execute()
     else:
-        if issue_type.title() not in types:
-            issuetype = inquirer.select("Select type:", types).execute()
-        else:
-            issuetype = issue_type
+        issuetype = matching_issue_type
 
     if ai_prompt:
         # typer does not currently support union types

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -18,7 +18,7 @@ FORBIDDEN_CREATE_ISSUETYPES = {"epic"}
 
 
 def is_forbidden_create_issuetype(issuetype: str | None) -> bool:
-    return bool(issuetype) and issuetype.strip().casefold() in FORBIDDEN_CREATE_ISSUETYPES
+    return issuetype.strip().casefold() in FORBIDDEN_CREATE_ISSUETYPES if issuetype else False
 
 
 def filter_creatable_issuetypes(issuetypes: list[str]) -> list[str]:

--- a/glu/jira.py
+++ b/glu/jira.py
@@ -14,6 +14,34 @@ from glu.config import EMAIL, JIRA_API_TOKEN, JIRA_SERVER, REPO_CONFIGS
 from glu.models import TICKET_PLACEHOLDER, IdReference, JiraUser, TicketGeneration
 from glu.utils import filterable_menu, print_error, print_panel
 
+FORBIDDEN_CREATE_ISSUETYPES = {"epic"}
+
+
+def is_forbidden_create_issuetype(issuetype: str | None) -> bool:
+    return bool(issuetype) and issuetype.strip().casefold() in FORBIDDEN_CREATE_ISSUETYPES
+
+
+def filter_creatable_issuetypes(issuetypes: list[str]) -> list[str]:
+    return [issuetype for issuetype in issuetypes if not is_forbidden_create_issuetype(issuetype)]
+
+
+def get_creatable_issuetypes_or_exit(
+    issuetype: str | None, issuetypes: list[str] | None
+) -> list[str] | None:
+    if is_forbidden_create_issuetype(issuetype):
+        print_error("Glu does not create Jira Epic tickets. Select a non-Epic issue type.")
+        raise typer.Exit(1)
+
+    if issuetypes is None:
+        return None
+
+    filtered_issuetypes = filter_creatable_issuetypes(issuetypes)
+    if not filtered_issuetypes and issuetype is None:
+        print_error("No non-Epic Jira issue types are available for ticket creation")
+        raise typer.Exit(1)
+
+    return filtered_issuetypes
+
 
 class JiraClient:
     def __init__(self):
@@ -48,6 +76,10 @@ class JiraClient:
         assignee_ref: IdReference,
         **extra_fields: dict,
     ) -> Issue:
+        if is_forbidden_create_issuetype(issuetype):
+            print_error("Glu does not create Jira Epic tickets. Select a non-Epic issue type.")
+            raise typer.Exit(1)
+
         fields = extra_fields | {
             "project": project,
             "issuetype": issuetype,
@@ -130,6 +162,8 @@ def generate_ticket_with_ai(
     requested_changes: str | None = None,
     previous_attempt: TicketGeneration | None = None,
 ) -> TicketGeneration:
+    issuetypes = get_creatable_issuetypes_or_exit(issuetype, issuetypes)
+
     ticket_data = generate_ticket(
         chat_client,
         repo_name,

--- a/tests/clients/jira.py
+++ b/tests/clients/jira.py
@@ -55,7 +55,7 @@ class FakeJiraClient:
         ]
 
     def get_issuetypes(self, project: str) -> list[str]:
-        return ["Bug", "Story", "Spike", "Chore", "Subtask"]
+        return ["Bug", "Story", "Epic", "Spike", "Chore", "Subtask"]
 
     def get_transitions(self, ticket_id: str) -> list[str]:
         if os.getenv("IS_JIRA_TICKET_IN_TO_DO"):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,6 @@
 from glu.ai import _trim_text_to_fit_token_limit
 from glu.config import MODEL_TOKEN_LIMITS
+from glu.jira import filter_creatable_issuetypes, is_forbidden_create_issuetype
 
 
 def test_trim_text():
@@ -27,3 +28,11 @@ def test_trim_text():
     for model in MODEL_TOKEN_LIMITS:
         output = _trim_text_to_fit_token_limit(text, model)
         assert len(output) == len(text)
+
+
+def test_epic_issuetype_is_not_creatable():
+    assert is_forbidden_create_issuetype("Epic")
+    assert is_forbidden_create_issuetype(" epic ")
+    assert not is_forbidden_create_issuetype("Story")
+
+    assert filter_creatable_issuetypes(["Bug", "Epic", "Story", "epic"]) == ["Bug", "Story"]

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -73,6 +73,7 @@ def _create_ticket(child: spawn, with_ai: bool = False, select_project: bool = F
     assert "Spike" in plain_menu
     assert "Bug" in plain_menu
     assert "Story" in plain_menu
+    assert "Epic" not in plain_menu
 
     # Move highlight down twice to select "Story"
     child.send(Key.DOWN.value)


### PR DESCRIPTION
### Description

- **Jira Ticket**: [XY-1234]
- **Summary**: Prevents Glu from creating Jira tickets with the **Epic** issuetype (including when issuetypes are generated/selected via the CLI and AI path).
- **Implementation details**: 
  - Added Jira helpers to treat **Epic** as a forbidden create issuetype: `is_forbidden_create_issuetype`, `filter_creatable_issuetypes`, and `get_creatable_issuetypes_or_exit`.
  - Updated Jira client ticket creation to fail fast (with a clear error + exit) if `issuetype` is Epic.
  - Updated both PR ticket creation (`glu/cli/pr/create.py`) and manual ticket creation (`glu/cli/ticket/create.py`) to filter out Epic from selectable/creatable issuetypes and to exit if no non-Epic types are available.
  - Ensured AI-generated ticket creation also respects the filtered set of creatable issuetypes via `generate_ticket_with_ai`.
  
### Changes

- **`glu/cli/pr/create.py`**: Filters Jira issuetypes to exclude Epic before generating a ticket; exits with an error if none remain.
- **`glu/cli/ticket/create.py`**: Filters out Epic from the selectable issuetype list; uses case-insensitive matching and blocks Epic via `is_forbidden_create_issuetype`.
- **`glu/jira.py`**: Centralized Epic-blocking logic; added guards in Jira ticket creation and AI ticket generation.
- **`tests/clients/jira.py`**: Fake Jira client now includes `Epic` to validate the filtering behavior.
- **`tests/test_misc.py`** / **`tests/test_tickets.py`**: Added/updated assertions to ensure Epic is not creatable and not shown in selection menus.

### Test Plan

- Added unit coverage for the Epic filtering/forbidden checks.
- Updated ticket CLI tests to verify **Epic** is not offered as a selectable issue type.

### Dependencies

- No new runtime dependencies introduced.

### Future Enhancements / Open questions / Risks / Technical Debt

- If other projects use additional “non-creatable” issuetypes beyond Epic, consider making the forbidden list configurable (currently hardcoded to `{"epic"}`).

### Checklist

- [ ] Code has been linted and adheres to the project's coding style guidelines.
- [ ] Tests have been added or modified for all new features and bug fixes.
- [ ] All FIXMEs have been addressed.
- [ ] Code changes or additions do not introduce significant performance issues.
- [ ] If necessary, documentation has been updated.
- [ ] I have sufficiently commented my code, either within this PR or the code itself,
      to guide reviewers and future coders through my changes and the intended results.
- [ ] I have selected reviewers who are knowledgeable about the code changes and the associated domain.
- [ ] Breaking changes: if checked, code is backward compatible or sufficient steps have been taken
    to not require backward compatibility.


Generated with [glu](https://github.com/BrightNight-Energy/glu)